### PR TITLE
Generate, serve, and show site preview

### DIFF
--- a/app/lib/common/models/Site.ts
+++ b/app/lib/common/models/Site.ts
@@ -8,6 +8,7 @@ export const Site = z.object({
 	group: z.string().nonempty(),
 	head: z.string(),
 	foot: z.string(),
+	preview: z.string().optional(),
 	index: z.number().int().nonnegative()
 })
 

--- a/app/lib/components/CreateSite.svelte
+++ b/app/lib/components/CreateSite.svelte
@@ -40,13 +40,12 @@
 
 	let site_name = $state(``)
 
-	let preview = $state(``)
-
 	let selected_starter_id = $state(``)
 	function select_starter(site_id) {
 		selected_starter_id = site_id
-		preview = ''
 	}
+
+	const selected_starter_site = $derived(starter_sites.find((site) => site.id === selected_starter_id))
 
 	const blank_site = {
 		head: '',
@@ -156,18 +155,16 @@
 					<div class="split-container flex-1">
 						<div class="h-[77vh] overflow-auto">
 							<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-								{@render StarterButton({
-									id: 'blank',
-									name: 'Blank',
-									data: blank_site
-								})}
+								{@render StarterButton('blank', 'Blank')}
 								{#each starter_sites as site}
-									{@render StarterButton(site)}
+									{@render StarterButton(site.id, site.name, site)}
 								{/each}
 							</div>
 						</div>
 						<div style="background: #222;" class="rounded">
-							<!-- <SitePreview style="height: 100%" site_id={selected_starter_id} {preview} append={design_variables_css} /> -->
+							{#if selected_starter_site}
+								<SitePreview style="height: 100%" site={selected_starter_site} />
+							{/if}
 						</div>
 					</div>
 				</div>
@@ -176,18 +173,18 @@
 	</Tabs.Root>
 </div>
 
-{#snippet StarterButton(site)}
-	<button onclick={() => select_starter(site.id)} class="space-y-3 relative w-full bg-gray-900 rounded overflow-hidden">
+{#snippet StarterButton(id: string, name: string, site?: Site)}
+	<button onclick={() => select_starter(id)} class="space-y-3 relative w-full bg-gray-900 rounded overflow-hidden">
 		<div class="relative">
-			<SitePreview />
-			{#if selected_starter_id === site.id}
+			<SitePreview {site} />
+			{#if selected_starter_id === id}
 				<div class="bg-black/70 absolute inset-0 w-full h-full flex items-center justify-center">
 					<Check />
 				</div>
 			{/if}
 		</div>
 		<div class="absolute bottom-0 w-full p-3 z-20 bg-gray-900 truncate flex items-center justify-between">
-			<div class="text-sm font-medium leading-none">{site.name}</div>
+			<div class="text-sm font-medium leading-none">{name}</div>
 		</div>
 	</button>
 {/snippet}

--- a/app/lib/components/MarketplaceStarterButton.svelte
+++ b/app/lib/components/MarketplaceStarterButton.svelte
@@ -68,7 +68,7 @@
 <div class="space-y-3 relative w-full bg-gray-900">
 	<div class="rounded-tl rounded-tr overflow-hidden">
 		<button class="w-full hover:opacity-75 transition-all" onclick={add_to_library} aria-hidden="true">
-			<SitePreview {preview} {append} />
+			<SitePreview {site} />
 		</button>
 	</div>
 	<div class="absolute -bottom-2 rounded-bl rounded-br w-full p-3 z-20 bg-gray-900 truncate flex items-center justify-between">

--- a/app/lib/components/SitePreview.svelte
+++ b/app/lib/components/SitePreview.svelte
@@ -1,19 +1,9 @@
 <script lang="ts">
-	import { tick, onDestroy } from 'svelte'
-	import { browser } from '$app/environment'
-	import { find as _find } from 'lodash-es'
-	import { Sites } from '$lib/pocketbase/collections'
+	import type { Site } from '$lib/common/models/Site'
+	import { Globe } from 'lucide-svelte'
+	import { onDestroy, tick } from 'svelte'
 
-	let { site_id, preview = $bindable(), head = '', append = '', style = '' }: { site_id?: string; preview?: string; head?: string; append?: string; style?: string } = $props()
-
-	const site = $derived(site_id ? Sites.one(site_id) : undefined)
-	const page = $derived(site?.homepage())
-	$effect(() => {
-		if (!preview && page) {
-			// TODO: Point iframe to page URL
-			preview = ''
-		}
-	})
+	let { site, style }: { site?: Site; style?: string } = $props()
 
 	let container = $state()
 	let scale = $state()
@@ -47,34 +37,6 @@
 		iframeHeight = `${100 / scale}%`
 	}
 
-	function append_to_head(code) {
-		var container = document.createElement('div')
-		container.innerHTML = code
-		Array.from(container.childNodes).forEach((node) => {
-			iframe.contentWindow.document.head.appendChild(node)
-		})
-	}
-
-	$effect(() => {
-		iframe && head && append_to_head(head)
-	})
-
-	function append_to_iframe(code) {
-		var container = document.createElement('div')
-
-		// Set the innerHTML of the container to your HTML string
-		container.innerHTML = code
-
-		// Append each element in the container to the document head
-		Array.from(container.childNodes).forEach((node) => {
-			iframe.contentWindow.document.body.appendChild(node)
-		})
-	}
-
-	$effect(() => {
-		iframe && append && append_to_iframe(append)
-	})
-
 	onDestroy(() => {
 		resize_observer?.disconnect()
 	})
@@ -83,24 +45,26 @@
 <svelte:window onresize={resize_preview} />
 
 <div class="iframe-root bg-gray-900" {style}>
-	<div bind:this={container} class="iframe-container z-10">
-		{#if browser && preview}
+	<div bind:this={container} class="iframe-container">
+		{#if site?.preview}
 			<iframe
 				tabindex="-1"
 				bind:this={iframe}
 				class="rounded overflow-hidden bg-white"
-				sandbox="allow-same-origin"
 				style="transform: scale({scale}); width: 1024px;"
 				style:height={iframeHeight}
 				class:fadein={iframeLoaded}
-				title="page preview"
-				srcdoc={preview + append}
+				title="site preview"
+				src={`/_preview/${site.id}`}
 				onload={async () => {
 					await init_preview()
-					iframeLoaded = !!preview
-					append_to_head(head)
+					iframeLoaded = true
 				}}
 			></iframe>
+		{:else}
+			<div class="h-full flex justify-center items-center">
+				<Globe color="white" size="5rem" />
+			</div>
 		{/if}
 	</div>
 </div>
@@ -114,7 +78,6 @@
 	.iframe-container {
 		position: absolute;
 		inset: 0;
-		z-index: 10;
 		opacity: 1;
 		transition: opacity 0.1s;
 		width: 100%;

--- a/app/routes/dashboard/sites/+page.svelte
+++ b/app/routes/dashboard/sites/+page.svelte
@@ -170,7 +170,7 @@
 	<div class="space-y-3 relative w-full bg-gray-900">
 		<div class="rounded-tl rounded-tr overflow-hidden">
 			<a data-sveltekit-prefetch href={`/admin/sites/${site.id}`}>
-				<SitePreview site_id={site.id} />
+				<SitePreview {site} />
 			</a>
 		</div>
 		<div class="absolute -bottom-2 rounded-bl rounded-br w-full p-3 z-20 bg-gray-900 truncate flex items-center justify-between">

--- a/pb_hooks/main.pb.js
+++ b/pb_hooks/main.pb.js
@@ -84,3 +84,28 @@ routerAdd('GET', '/{path...}', (e) => {
 		fsys?.close()
 	}
 })
+
+routerAdd('GET', '/_preview/{site}', (e) => {
+	const siteId = e.request.pathValue('site')
+	let site
+	try {
+		site = $app.findRecordById('sites', siteId)
+	} catch {
+		return e.string(404, 'Site not found')
+	}
+
+	// Respond with compiled HTML
+	const fileKey = site.baseFilesPath() + '/' + site.get('preview')
+	let fsys, reader, content
+	try {
+		fsys = $app.newFilesystem()
+		reader = fsys.getFile(fileKey)
+		content = toString(reader)
+		return e.blob(200, 'text/html', content)
+	} catch {
+		return e.string(404, 'Preview not found')
+	} finally {
+		reader?.close()
+		fsys?.close()
+	}
+})

--- a/pb_migrations/1754299877_updated_sites.js
+++ b/pb_migrations/1754299877_updated_sites.js
@@ -1,0 +1,35 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2001081480')
+
+		// add field
+		collection.fields.addAt(
+			7,
+			new Field({
+				hidden: false,
+				id: 'file3112513328',
+				maxSelect: 1,
+				maxSize: 0,
+				mimeTypes: [],
+				name: 'preview',
+				presentable: false,
+				protected: false,
+				required: false,
+				system: false,
+				thumbs: [],
+				type: 'file'
+			})
+		)
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_2001081480')
+
+		// remove field
+		collection.fields.removeById('file3112513328')
+
+		return app.save(collection)
+	}
+)


### PR DESCRIPTION
- Generate site preview (homepage without JS) on publish
- Serve site previews from route /_preview (note: no authentication)
- Show site previews in IFrame
- If there's no site preview, show globe icon