### PR TITLE
Fix section field change

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,0 @@
-{
-  "statusLine": {
-    "type": "command",
-    "command": "bun x ccusage statusline"
-  }
-}

--- a/app/lib/builder/components/misc.js
+++ b/app/lib/builder/components/misc.js
@@ -109,11 +109,11 @@ export const component_iframe_srcdoc = ({ head = '', foot = '' }) => {
               if (c) unmount(c)
               try {
                 c = mount(App, {
-                  target: document.querySelector('#page'),
+                  target: document.querySelector('body'),
                   props
                 })
               } catch(e) {
-                document.querySelector('#page').innerHTML = ''
+                document.querySelector('body').innerHTML = ''
                 console.error(e.toString())
               }
             })
@@ -121,7 +121,7 @@ export const component_iframe_srcdoc = ({ head = '', foot = '' }) => {
         </script>
         ${head}
       </head>
-      <body id="page" style="margin:0;overflow:hidden;">
+      <body style="margin:0;overflow:hidden;">
         ${foot}
         <style>
           [contenteditable="true"] { outline: 0 !important; }

--- a/app/lib/builder/components/misc.js
+++ b/app/lib/builder/components/misc.js
@@ -109,11 +109,11 @@ export const component_iframe_srcdoc = ({ head = '', foot = '' }) => {
               if (c) unmount(c)
               try {
                 c = mount(App, {
-                  target: document.querySelector('#component'),
+                  target: document.querySelector('#page'),
                   props
                 })
               } catch(e) {
-                document.querySelector('body').innerHTML = ''
+                document.querySelector('#page').innerHTML = ''
                 console.error(e.toString())
               }
             })
@@ -122,7 +122,6 @@ export const component_iframe_srcdoc = ({ head = '', foot = '' }) => {
         ${head}
       </head>
       <body id="page" style="margin:0;overflow:hidden;">
-        <div id="component"></div>
         ${foot}
         <style>
           [contenteditable="true"] { outline: 0 !important; }

--- a/app/lib/builder/components/misc.js
+++ b/app/lib/builder/components/misc.js
@@ -109,11 +109,11 @@ export const component_iframe_srcdoc = ({ head = '', foot = '' }) => {
               if (c) unmount(c)
               try {
                 c = mount(App, {
-                  target: document.querySelector('body'),
+                  target: document.querySelector('#component'),
                   props
                 })
               } catch(e) {
-                document.querySelector('body').innerHTML = ''
+                document.querySelector('#component').innerHTML = ''
                 console.error(e.toString())
               }
             })
@@ -122,6 +122,7 @@ export const component_iframe_srcdoc = ({ head = '', foot = '' }) => {
         ${head}
       </head>
       <body style="margin:0;overflow:hidden;">
+        <div id="component"></div>
         ${foot}
         <style>
           [contenteditable="true"] { outline: 0 !important; }

--- a/app/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/app/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
-	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui'
+	import { cn } from '$lib/utils.js'
 
-	let {
-		class: className,
-		ref = $bindable(null),
-		...restProps
-	}: AlertDialogPrimitive.OverlayProps = $props();
+	let { class: className, ref = $bindable(null), ...restProps }: AlertDialogPrimitive.OverlayProps = $props()
 </script>
 
 <AlertDialogPrimitive.Overlay
 	bind:ref
-	class={cn(
-		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
-		className
-	)}
+	class={cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80', className)}
 	{...restProps}
 />

--- a/app/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/app/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
-	import { Dialog as DialogPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Dialog as DialogPrimitive } from 'bits-ui'
+	import { cn } from '$lib/utils.js'
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		...restProps
-	}: DialogPrimitive.OverlayProps = $props();
+	let { ref = $bindable(null), class: className, ...restProps }: DialogPrimitive.OverlayProps = $props()
 </script>
 
 <DialogPrimitive.Overlay
 	bind:ref
-	class={cn(
-		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
-		className
-	)}
+	class={cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[999] bg-black/80', className)}
 	{...restProps}
 />


### PR DESCRIPTION
Addresses the issue where adding/removing a field from SectionEditor and saving would break the section, forcing the user to refresh the page to render the section correctly. Caused by data changes being passed to the on-page section while in the modal, and when those changes break the section it couldn't reload correctly because the node would be removed in the process. Changing the initialization function to just reference the body tag directly fixed the error. 