### PR TITLE
Setup palacms.com

### DIFF
--- a/app/lib/builder/field-types/Link.svelte
+++ b/app/lib/builder/field-types/Link.svelte
@@ -79,7 +79,7 @@
 					}}
 					value={entry.value.url}
 					type="url"
-					placeholder="https://palacms.org"
+					placeholder="https://palacms.com"
 				/>
 			{/if}
 		</div>

--- a/app/lib/pocketbase/PocketBase.ts
+++ b/app/lib/pocketbase/PocketBase.ts
@@ -1,7 +1,7 @@
 import PocketBase from 'pocketbase'
 
 export const self = new PocketBase(import.meta.env.DEV ? 'http://127.0.0.1:8090' : '/')
-export const marketplace = new PocketBase('https://marketplace.palacms.org')
+export const marketplace = new PocketBase('https://marketplace.palacms.com')
 
 export const checkSession = async () => {
 	if (self.authStore.isValid) {

--- a/deployment/production/compose.yaml
+++ b/deployment/production/compose.yaml
@@ -15,29 +15,29 @@ services:
       - traefik.http.services.production-palacms.loadbalancer.server.port=8080
       - traefik.http.routers.production-palacms-http.entrypoints=http
       - traefik.http.routers.production-palacms-http.middlewares=https-redirect
-      - traefik.http.routers.production-palacms-http.rule=Host(`palacms.org`) || Host(`marketplace.palacms.org`)
+      - traefik.http.routers.production-palacms-http.rule=Host(`palacms.com`) || Host(`marketplace.palacms.com`)
 
       - traefik.http.routers.production-palacms-https.entrypoints=https
-      - traefik.http.routers.production-palacms-https.rule=Host(`palacms.org`)
+      - traefik.http.routers.production-palacms-https.rule=Host(`palacms.com`)
       - traefik.http.routers.production-palacms-https.service=production-palacms
       - traefik.http.routers.production-palacms-https.tls=true
       - traefik.http.routers.production-palacms-https.tls.certresolver=le
 
       - traefik.http.routers.marketplace-palacms-https.entrypoints=https
-      - traefik.http.routers.marketplace-palacms-https.rule=Host(`marketplace.palacms.org`)
+      - traefik.http.routers.marketplace-palacms-https.rule=Host(`marketplace.palacms.com`)
       - traefik.http.routers.marketplace-palacms-https.tls=true
       - traefik.http.routers.marketplace-palacms-https.tls.certresolver=le
       - traefik.http.routers.marketplace-palacms-https.middlewares=marketplace-palacms-redirect
 
       - traefik.http.routers.marketplace-palacms-https-api.entrypoints=https
-      - traefik.http.routers.marketplace-palacms-https-api.rule=Host(`marketplace.palacms.org`) && PathPrefix(`/api`)
+      - traefik.http.routers.marketplace-palacms-https-api.rule=Host(`marketplace.palacms.com`) && PathPrefix(`/api`)
       - traefik.http.routers.marketplace-palacms-https-api.service=production-palacms
       - traefik.http.routers.marketplace-palacms-https-api.tls=true
       - traefik.http.routers.marketplace-palacms-https-api.tls.certresolver=le
       - traefik.http.routers.marketplace-palacms-https-api.middlewares=marketplace-palacms-cors
 
       - traefik.http.middlewares.marketplace-palacms-redirect.redirectregex.regex=.*
-      - traefik.http.middlewares.marketplace-palacms-redirect.redirectregex.replacement=https://palacms.org
+      - traefik.http.middlewares.marketplace-palacms-redirect.redirectregex.replacement=https://palacms.com
       - traefik.http.middlewares.marketplace-palacms-cors.headers.accesscontrolalloworiginlist=*
 
 volumes:

--- a/deployment/testing/compose.yaml
+++ b/deployment/testing/compose.yaml
@@ -15,9 +15,9 @@ services:
       - traefik.http.services.testing-palacms.loadbalancer.server.port=8080
       - traefik.http.routers.testing-palacms-http.entrypoints=http
       - traefik.http.routers.testing-palacms-http.middlewares=https-redirect
-      - traefik.http.routers.testing-palacms-http.rule=Host(`testing.palacms.org`)
+      - traefik.http.routers.testing-palacms-http.rule=Host(`testing.palacms.com`)
       - traefik.http.routers.testing-palacms-https.entrypoints=https
-      - traefik.http.routers.testing-palacms-https.rule=Host(`testing.palacms.org`)
+      - traefik.http.routers.testing-palacms-https.rule=Host(`testing.palacms.com`)
       - traefik.http.routers.testing-palacms-https.service=testing-palacms
       - traefik.http.routers.testing-palacms-https.tls=true
       - traefik.http.routers.testing-palacms-https.tls.certresolver=le

--- a/pb_hooks/main.pb.js
+++ b/pb_hooks/main.pb.js
@@ -102,7 +102,7 @@ routerAdd('GET', '/{path...}', (e) => {
 	let fsys, reader, content
 	try {
 		fsys = $app.newFilesystem()
-		reader = fsys.getFile(fileKey)
+		reader = fsys.getReader(fileKey)
 		content = toString(reader)
 		return e.blob(200, 'text/html', content)
 	} finally {


### PR DESCRIPTION
- Changed all domain names from palacms.org to palacms.com
- Also fixed the bug that causes crashing

Before this is merged, following DNS records could be added for palacms.com:

| Type  | Host    | Value          |
| ----- | ------- | -------------- |
| CNAME | testing | mako.pala.dev. |
| CNAME | marketplace | mako.pala.dev. |