### PR TITLE
Implement image upload

### DIFF
--- a/app/lib/PageData.svelte.ts
+++ b/app/lib/PageData.svelte.ts
@@ -16,8 +16,10 @@ export const usePageData = (site?: ObjectOf<typeof Sites>, pages?: ObjectOf<type
 			[...page_sections, ...page_type_sections]
 				.map((section) => SiteSymbols.one(section.symbol))
 				.filter((symbol) => symbol !== undefined)
+				.filter((symbol) => symbol !== null)
 				.filter(deduplicate('id'))
 	)
+	const site_uploads = $derived(site?.uploads())
 	const site_fields = $derived(site?.fields())
 	const page_type_fields = $derived(
 		page_types?.every((page_type) => page_type.fields() !== undefined) ? page_types.flatMap((page_type) => page_type.fields() ?? []).filter(deduplicate('id')) : undefined
@@ -45,6 +47,7 @@ export const usePageData = (site?: ObjectOf<typeof Sites>, pages?: ObjectOf<type
 				page_type_sections &&
 				page_type_symbols &&
 				symbols &&
+				site_uploads &&
 				site_fields &&
 				page_type_fields &&
 				symbol_fields &&
@@ -61,6 +64,7 @@ export const usePageData = (site?: ObjectOf<typeof Sites>, pages?: ObjectOf<type
 					page_type_sections,
 					page_type_symbols,
 					symbols,
+					site_uploads,
 					site_fields,
 					page_type_fields,
 					symbol_fields,

--- a/app/lib/builder/Pala.svelte
+++ b/app/lib/builder/Pala.svelte
@@ -131,7 +131,7 @@
 		$site_html = null
 	})
 
-	const site_data = $derived(site ? getContent(site, site.fields() || [], site.entries() || [])['en'] : {})
+	const site_data = $derived(site ? getContent(site, site.fields() || [], site.entries() || [], site.uploads() || [])['en'] : {})
 	async function compile_component_head({ html, data }) {
 		const compiled = await processCode({
 			component: {

--- a/app/lib/builder/code_generators.ts
+++ b/app/lib/builder/code_generators.ts
@@ -17,6 +17,7 @@ import type { PageTypeSymbol } from '$lib/common/models/PageTypeSymbol.js'
 import type { SiteSymbol } from '$lib/common/models/SiteSymbol.js'
 import type { SiteSymbolEntry } from '$lib/common/models/SiteSymbolEntry.js'
 import type { PageEntry } from '$lib/common/models/PageEntry.js'
+import type { SiteUpload } from '$lib/common/models/SiteUpload.js'
 
 export async function block_html({ code, data }) {
 	const { html, css: postcss, js } = code
@@ -44,6 +45,7 @@ export async function page_html({
 	page_type_entries,
 	page_section_entries,
 	page_type_section_entries,
+	site_uploads,
 	locale = 'en',
 	no_js = false
 }: {
@@ -63,11 +65,12 @@ export async function page_html({
 	page_entries: PageEntry[]
 	page_section_entries: PageSectionEntry[]
 	page_type_section_entries: PageTypeSectionEntry[]
+	site_uploads: SiteUpload[]
 	locale?: (typeof locales)[number]
 	no_js?: boolean
 }) {
-	const site_content = getContent(site, site_fields, site_entries)
-	const page_type_content = getContent(page_type, page_type_fields, page_type_entries)
+	const site_content = getContent(site, site_fields, site_entries, site_uploads)
+	const page_type_content = getContent(page_type, page_type_fields, page_type_entries, site_uploads)
 
 	// Flatten the content for template variables (extract from locale structure)
 	const site_data = {
@@ -100,7 +103,7 @@ export async function page_html({
 
 				const { html, css: postcss, js } = symbol
 
-				const data = getContent(section, symbol_fields, section_entries)[locale] ?? {}
+				const data = getContent(section, symbol_fields, section_entries, site_uploads)[locale] ?? {}
 
 				// @ts-ignore
 				const { css, error } = await processors.css(postcss || '')
@@ -155,7 +158,7 @@ export async function page_html({
 					sections
 						.filter((section) => section.symbol === symbol.id)
 						.map((section) => {
-							const instance_content = getContent(section, symbol_fields, section_entries)[locale]
+							const instance_content = getContent(section, symbol_fields, section_entries, site_uploads)[locale]
 							return `hydrate(App, { target: document.querySelector('#section-${section.id}'), props: ${JSON.stringify(instance_content)} });`
 						})
 						.join('') +

--- a/app/lib/builder/components/ComponentPreview.svelte
+++ b/app/lib/builder/components/ComponentPreview.svelte
@@ -52,7 +52,7 @@
 		append = ''
 	} = $props()
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 
 	$preview_updated = false
 

--- a/app/lib/builder/components/Fields/FieldItem.svelte
+++ b/app/lib/builder/components/Fields/FieldItem.svelte
@@ -43,7 +43,7 @@
 		onmove: (id: string, direction: 'up' | 'down') => void
 	} = $props()
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const page_types = $derived(site?.page_types() ?? [])
 
 	const visible_field_types = hide_dynamic_field_types_context.getOr(false)

--- a/app/lib/builder/components/Fields/ImageFieldOptions.svelte
+++ b/app/lib/builder/components/Fields/ImageFieldOptions.svelte
@@ -9,14 +9,22 @@
 	// Initialize config object if it doesn't exist
 	if (!field.config) field.config = {}
 
-	// Set defaults if values don't exist
-	if (field.config.maxSizeMB === undefined) field.config.maxSizeMB = 1
-	if (field.config.maxWidthOrHeight === undefined) field.config.maxWidthOrHeight = 1920
-
 	// Listen for changes to dispatch updates to parent
 	function handle_change() {
 		dispatch('input', { config: field.config })
 	}
+
+	$effect(() => {
+		// Set defaults if values don't exist
+		if (field.config.maxSizeMB === undefined) {
+			field.config.maxSizeMB = 1
+			handle_change()
+		}
+		if (field.config.maxWidthOrHeight === undefined) {
+			field.config.maxWidthOrHeight = 1920
+			handle_change()
+		}
+	})
 </script>
 
 <div class="ImageFieldOptions">

--- a/app/lib/builder/components/Fields/PageField.svelte
+++ b/app/lib/builder/components/Fields/PageField.svelte
@@ -4,7 +4,7 @@
 	import type { PageField } from '$lib/common/models/fields/PageField'
 	import UI from '../../ui/index.js'
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const { field }: { field: PageField } = $props()
 
 	const dispatch = createEventDispatcher()

--- a/app/lib/builder/components/Fields/PageFieldField.svelte
+++ b/app/lib/builder/components/Fields/PageFieldField.svelte
@@ -7,7 +7,7 @@
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte.js'
 	import { watch } from 'runed'
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const { field }: { field: PageFieldField } = $props()
 
 	const dispatch = createEventDispatcher()

--- a/app/lib/builder/components/Fields/PageListField.svelte
+++ b/app/lib/builder/components/Fields/PageListField.svelte
@@ -3,7 +3,7 @@
 	import type { PageListField } from '$lib/common/models/fields/PageListField.js'
 	import { site_context } from '$lib/builder/stores/context'
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const { field }: { field: PageListField } = $props()
 </script>
 

--- a/app/lib/builder/components/Fields/SiteFieldField.svelte
+++ b/app/lib/builder/components/Fields/SiteFieldField.svelte
@@ -6,7 +6,7 @@
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte.js'
 	import { watch } from 'runed'
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	let { field } = $props()
 
 	const dispatch = createEventDispatcher()

--- a/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/PageType_Sidebar.svelte
@@ -27,7 +27,7 @@
 	import { tick } from 'svelte'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte.ts'
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const page_type_id = $derived(page.params.page_type)
 	const page_type = $derived(PageTypes.one(page_type_id))
 	const fields = $derived(page_type?.fields() ?? [])

--- a/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
+++ b/app/lib/builder/components/Sidebar/Page_Sidebar.svelte
@@ -20,8 +20,7 @@
 	import { current_user } from '$lib/pocketbase/user'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte'
 
-	// Get site from context (preferred) or fallback to hostname lookup
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const slug = $derived(pageState.params.page)
 	const page = $derived(site && slug ? Pages.list({ filter: `site = "${site.id}" && slug = "${slug}"` })?.[0] : site?.homepage())
 	const page_type = $derived(page && PageTypes.one(page.page_type))

--- a/app/lib/builder/components/Sidebar/Sidebar_Symbol.svelte
+++ b/app/lib/builder/components/Sidebar/Sidebar_Symbol.svelte
@@ -13,7 +13,7 @@
 	import { createEventDispatcher, onMount } from 'svelte'
 	import { block_html } from '$lib/builder/code_generators'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte'
-	import { manager, SiteSymbols } from '$lib/pocketbase/collections'
+	import { manager, Sites, SiteSymbols } from '$lib/pocketbase/collections'
 	import { useExportSiteSymbol } from '$lib/ExportSymbol.svelte'
 
 	const dispatch = createEventDispatcher()
@@ -63,9 +63,11 @@
 		css: symbol.css,
 		js: symbol.js
 	})
+	const site = $derived(Sites.one(symbol.site))
 	const fields = $derived(symbol.fields())
 	const entries = $derived(symbol.entries())
-	const data = $derived(fields && entries && (getContent(symbol, fields, entries)[$locale] ?? {}))
+	const uploads = $derived(site?.uploads())
+	const data = $derived(fields && entries && uploads && (getContent(symbol, fields, entries, uploads)[$locale] ?? {}))
 
 	let componentCode = $state()
 	let component_error = $state()

--- a/app/lib/builder/components/Site_Symbol.svelte
+++ b/app/lib/builder/components/Site_Symbol.svelte
@@ -14,7 +14,7 @@
 
 	let { symbol = $bindable(), checked = false, onclick }: { symbol: SiteSymbol | LibrarySymbol; checked?: boolean; onclick?: () => void } = $props()
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 
 	let name_el
 

--- a/app/lib/builder/field-types/Link.svelte
+++ b/app/lib/builder/field-types/Link.svelte
@@ -18,7 +18,7 @@
 
 	const default_entry = { value: default_value }
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const entry = $derived(passedEntry || default_entry)
 	const selectable_pages = $derived(site?.pages() ?? [])
 

--- a/app/lib/builder/field-types/PageField.svelte
+++ b/app/lib/builder/field-types/PageField.svelte
@@ -7,7 +7,7 @@
 	import { site_context } from '$lib/builder/stores/context'
 
 	const { entity, field, entry, onchange }: { entity: Entity; field: PageField; entry?: Entry; onchange: FieldValueHandler } = $props()
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const selectable_pages = $derived.by(() => {
 		const pages = site?.pages() ?? []
 		const filtered = pages.filter((p) => p.page_type === field.config.page_type)

--- a/app/lib/builder/field-types/SiteField.svelte
+++ b/app/lib/builder/field-types/SiteField.svelte
@@ -34,7 +34,7 @@
 		return $fieldTypes.find((ft) => ft.id === resolvedField.type)
 	})
 
-	const site = site_context.get()
+	const site = site_context.getOr(null)
 	const fields = $derived(site?.fields() ?? [])
 	const entries = $derived(site?.entries() ?? [])
 	const entry = $derived(resolvedField && getDirectEntries(entity, resolvedField, entries)[0])

--- a/app/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/app/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -25,7 +25,7 @@
 	import { component_iframe_srcdoc } from '$lib/builder/components/misc'
 	import { getContent } from '$lib/pocketbase/content'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte'
-	import { SiteSymbols, type PageSections, type PageTypeSections, PageSectionEntries, PageTypeSectionEntries, manager } from '$lib/pocketbase/collections'
+	import { SiteSymbols, type PageSections, type PageTypeSections, PageSectionEntries, PageTypeSectionEntries, manager, Sites } from '$lib/pocketbase/collections'
 	import { Editor, Extension } from '@tiptap/core'
 	import { renderToHTMLString, renderToMarkdown } from '@tiptap/static-renderer'
 
@@ -60,9 +60,11 @@
 
 	let node = $state()
 
+	const site = $derived(Sites.one(block.site))
 	const fields = $derived(block.fields())
 	const entries = $derived('page_type' in section ? section.entries() : 'page' in section ? section.entries() : undefined)
-	const component_data = $derived(fields && entries && (getContent(section, fields, entries)[$locale] ?? {}))
+	const uploads = $derived(site?.uploads())
+	const component_data = $derived(fields && entries && uploads && (getContent(section, fields, entries, uploads)[$locale] ?? {}))
 
 	let floating_menu = $state()
 	let bubble_menu = $state()

--- a/app/lib/builder/views/modal/SectionEditor/SectionEditor.svelte
+++ b/app/lib/builder/views/modal/SectionEditor/SectionEditor.svelte
@@ -17,11 +17,11 @@
 	import { PressedKeys } from 'runed'
 	import { onModKey } from '$lib/builder/utils/keyboard'
 	import { browser } from '$app/environment'
-	import { PageSectionEntries, PageSections, PageEntries, PageTypeSectionEntries, SiteSymbolFields, SiteSymbols, SiteSymbolEntries, SiteEntries, manager } from '$lib/pocketbase/collections'
+	import { PageSectionEntries, PageSections, PageEntries, PageTypeSectionEntries, SiteSymbolFields, SiteSymbols, SiteSymbolEntries, SiteEntries, manager, Sites } from '$lib/pocketbase/collections'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte'
 	import type { PageTypeSection } from '$lib/common/models/PageTypeSection'
 	import { current_user } from '$lib/pocketbase/user'
-	import _ from 'lodash-es'
+	import * as _ from 'lodash-es'
 
 	let {
 		component,
@@ -48,9 +48,11 @@
 	// Data will be loaded automatically by CollectionMapping system when accessed
 
 	const symbol = $derived(SiteSymbols.one(component.symbol))
+	const site = $derived(symbol && Sites.one(symbol.site))
 	const fields = $derived(symbol?.fields())
 	const entries = $derived('page_type' in component ? component.entries() : 'page' in component ? component.entries() : undefined)
-	const component_data = $derived(fields && entries && (getContent(component, fields, entries)[$locale] ?? {}))
+	const uploads = $derived(site?.uploads())
+	const component_data = $derived(fields && entries && uploads && (getContent(component, fields, entries, uploads)[$locale] ?? {}))
 
 	const initial_code = { html: symbol?.html, css: symbol?.css, js: symbol?.js }
 	const initial_data = _.cloneDeep(component_data)
@@ -95,13 +97,13 @@
 
 	// Set up hotkey listeners for modal
 	const modalKeys = new PressedKeys()
-	
+
 	// Toggle between code and content tabs
 	onModKey(modalKeys, 'e', toggle_tab)
-	
+
 	// Save component
 	onModKey(modalKeys, 's', save_component)
-	
+
 	// Also keep listening to global hotkey events for compatibility
 	$effect.pre(() => {
 		const unsubscribe_e = hotkey_events.on('e', toggle_tab)

--- a/app/lib/builder/views/modal/SiteEditor/SiteEditor.svelte
+++ b/app/lib/builder/views/modal/SiteEditor/SiteEditor.svelte
@@ -17,7 +17,8 @@
 	const site = site_context.get()
 	const fields = $derived(site?.fields() ?? [])
 	const entries = $derived(site?.entries() ?? [])
-	const site_data = $derived(fields && entries && (getContent(site, fields, entries)['en'] ?? {}))
+	const uploads = $derived(site.uploads())
+	const site_data = $derived(fields && entries && uploads && (getContent(site, fields, entries, uploads)['en'] ?? {}))
 
 	hide_dynamic_field_types_context.set(true)
 

--- a/app/lib/common/models/LibraryUpload.ts
+++ b/app/lib/common/models/LibraryUpload.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+import { Upload } from './Upload'
+
+export const LibraryUpload = Upload
+
+export type LibraryUpload = z.infer<typeof LibraryUpload>

--- a/app/lib/common/models/Page.ts
+++ b/app/lib/common/models/Page.ts
@@ -4,7 +4,7 @@ export const Page = z.object({
 	id: z.string().nonempty(),
 	name: z.string().nonempty(),
 	slug: z.string(),
-	compiled_html: z.string().optional(),
+	compiled_html: z.string().or(z.file()).optional(),
 	page_type: z.string().nonempty(),
 	parent: z.string(),
 	site: z.string().nonempty()

--- a/app/lib/common/models/Site.ts
+++ b/app/lib/common/models/Site.ts
@@ -8,7 +8,7 @@ export const Site = z.object({
 	group: z.string().nonempty(),
 	head: z.string(),
 	foot: z.string(),
-	preview: z.string().optional(),
+	preview: z.string().or(z.file()).optional(),
 	index: z.number().int().nonnegative()
 })
 

--- a/app/lib/common/models/SiteSymbol.ts
+++ b/app/lib/common/models/SiteSymbol.ts
@@ -3,7 +3,7 @@ import { Symbol } from './Symbol'
 
 export const SiteSymbol = Symbol.extend({
 	site: z.string().nonempty(),
-	compiled_js: z.string().optional()
+	compiled_js: z.string().or(z.file()).optional()
 })
 
 export type SiteSymbol = z.infer<typeof SiteSymbol>

--- a/app/lib/common/models/SiteUpload.ts
+++ b/app/lib/common/models/SiteUpload.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+import { Upload } from './Upload'
+
+export const SiteUpload = Upload.extend({
+	site: z.string().nonempty()
+})
+
+export type SiteUpload = z.infer<typeof SiteUpload>

--- a/app/lib/common/models/Upload.ts
+++ b/app/lib/common/models/Upload.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const Upload = z.object({
+	id: z.string().nonempty(),
+	file: z.string().nonempty().or(z.instanceof(File))
+})
+
+export type Upload = z.infer<typeof Upload>

--- a/app/lib/common/models/Upload.ts
+++ b/app/lib/common/models/Upload.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const Upload = z.object({
 	id: z.string().nonempty(),
-	file: z.string().nonempty().or(z.instanceof(File))
+	file: z.string().nonempty().or(z.file())
 })
 
 export type Upload = z.infer<typeof Upload>

--- a/app/lib/common/models/index.ts
+++ b/app/lib/common/models/index.ts
@@ -21,6 +21,8 @@ import { PageTypeField } from './PageTypeField'
 import { PageTypeEntry } from './PageTypeEntry'
 import { PageEntry } from './PageEntry'
 import { SiteRoleAssignment } from './SiteRoleAssignment'
+import { SiteUpload } from './SiteUpload'
+import { LibraryUpload } from './LibraryUpload'
 
 /**
  * Model for each collection. Used in a PocketBase hook to validate records.
@@ -31,6 +33,7 @@ export const models = {
 	library_symbol_fields: LibrarySymbolField,
 	library_symbol_groups: LibrarySymbolGroup,
 	library_symbols: LibrarySymbol,
+	library_upload: LibraryUpload,
 	page_entries: PageEntry,
 	page_section_entries: PageSectionEntry,
 	page_sections: PageSection,
@@ -48,5 +51,6 @@ export const models = {
 	site_symbol_entries: SiteSymbolEntry,
 	site_symbol_fields: SiteSymbolField,
 	site_symbols: SiteSymbol,
+	site_uploads: SiteUpload,
 	sites: Site
 } satisfies Record<string, import('zod').ZodType>

--- a/app/lib/components/SymbolButton.svelte
+++ b/app/lib/components/SymbolButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import IFrame from '$lib/builder/components/IFrame.svelte'
-	import { LibrarySymbols } from '$lib/pocketbase/collections'
+	import { LibrarySymbols, LibraryUploads } from '$lib/pocketbase/collections'
 	import { block_html } from '$lib/builder/code_generators'
 	import type { Snippet } from 'svelte'
 	import { getContent } from '$lib/pocketbase/content'
@@ -27,7 +27,8 @@
 	)
 	const fields = $derived(symbol?.fields())
 	const entries = $derived(symbol?.entries())
-	const data = $derived(symbol && fields && entries && (getContent(symbol, fields, entries)[$locale] ?? {}))
+	const uploads = $derived(LibraryUploads.list())
+	const data = $derived(symbol && fields && entries && uploads && (getContent(symbol, fields, entries, uploads)[$locale] ?? {}))
 
 	let generated_code = $state()
 	$effect(() => {

--- a/app/lib/pocketbase/PocketBase.ts
+++ b/app/lib/pocketbase/PocketBase.ts
@@ -1,6 +1,6 @@
 import PocketBase from 'pocketbase'
 
-export const self = new PocketBase(import.meta.env.DEV ? 'http://127.0.0.1:8090' : '/')
+export const self = new PocketBase(import.meta.env.DEV ? 'http://127.0.0.1:8090' : location.origin)
 export const marketplace = new PocketBase('https://marketplace.palacms.com')
 
 export const checkSession = async () => {

--- a/app/lib/pocketbase/collections.ts
+++ b/app/lib/pocketbase/collections.ts
@@ -96,6 +96,9 @@ export const Sites = createCollectionMapping('sites', Site, manager, {
 		entries() {
 			return SiteEntries.from(this.collection.instance).list({ filter: `field.site = "${this.id}"` })
 		},
+		uploads() {
+			return SiteUploads.from(this.collection.instance).list({ filter: `site = "${this.id}"` })
+		},
 		page_types() {
 			return PageTypes.from(this.collection.instance).list({ filter: `site = "${this.id}"` })
 		},

--- a/app/lib/pocketbase/collections.ts
+++ b/app/lib/pocketbase/collections.ts
@@ -2,6 +2,7 @@ import { LibrarySymbol } from '$lib/common/models/LibrarySymbol'
 import { LibrarySymbolEntry } from '$lib/common/models/LibrarySymbolEntry'
 import { LibrarySymbolField } from '$lib/common/models/LibrarySymbolField'
 import { LibrarySymbolGroup } from '$lib/common/models/LibrarySymbolGroup'
+import { LibraryUpload } from '$lib/common/models/LibraryUpload'
 import { Page } from '$lib/common/models/Page'
 import { PageEntry } from '$lib/common/models/PageEntry'
 import { PageSection } from '$lib/common/models/PageSection'
@@ -20,6 +21,7 @@ import { SiteRoleAssignment } from '$lib/common/models/SiteRoleAssignment'
 import { SiteSymbol } from '$lib/common/models/SiteSymbol'
 import { SiteSymbolEntry } from '$lib/common/models/SiteSymbolEntry'
 import { SiteSymbolField } from '$lib/common/models/SiteSymbolField'
+import { SiteUpload } from '$lib/common/models/SiteUpload'
 import { User } from '$lib/common/models/User'
 import { createCollectionManager } from './CollectionManager'
 import { createCollectionMapping } from './CollectionMapping.svelte'
@@ -65,6 +67,10 @@ export const LibrarySymbolFields = createCollectionMapping('library_symbol_field
 })
 
 export const LibrarySymbolEntries = createCollectionMapping('library_symbol_entries', LibrarySymbolEntry, manager, {
+	links: {}
+})
+
+export const LibraryUploads = createCollectionMapping('library_uploads', LibraryUpload, manager, {
 	links: {}
 })
 
@@ -213,5 +219,9 @@ export const PageSections = createCollectionMapping('page_sections', PageSection
 })
 
 export const PageSectionEntries = createCollectionMapping('page_section_entries', PageSectionEntry, manager, {
+	links: {}
+})
+
+export const SiteUploads = createCollectionMapping('site_uploads', SiteUpload, manager, {
 	links: {}
 })

--- a/pb_migrations/1755961535_created_site_uploads.js
+++ b/pb_migrations/1755961535_created_site_uploads.js
@@ -1,0 +1,87 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = new Collection({
+			createRule: '(@request.auth.serverRole != "") || (@collection.site_role_assignments.user.id = @request.auth.id && @collection.site_role_assignments.site.id = id)',
+			deleteRule: '(@request.auth.serverRole != "") || (@collection.site_role_assignments.user.id = @request.auth.id && @collection.site_role_assignments.site.id = id)',
+			fields: [
+				{
+					autogeneratePattern: '[a-z0-9]{15}',
+					hidden: false,
+					id: 'text3208210256',
+					max: 15,
+					min: 15,
+					name: 'id',
+					pattern: '^[a-z0-9]+$',
+					presentable: false,
+					primaryKey: true,
+					required: true,
+					system: true,
+					type: 'text'
+				},
+				{
+					cascadeDelete: true,
+					collectionId: 'pbc_2001081480',
+					hidden: false,
+					id: 'relation1766001124',
+					maxSelect: 1,
+					minSelect: 0,
+					name: 'site',
+					presentable: false,
+					required: true,
+					system: false,
+					type: 'relation'
+				},
+				{
+					hidden: false,
+					id: 'file2359244304',
+					maxSelect: 1,
+					maxSize: 0,
+					mimeTypes: [],
+					name: 'file',
+					presentable: false,
+					protected: false,
+					required: true,
+					system: false,
+					thumbs: [],
+					type: 'file'
+				},
+				{
+					hidden: false,
+					id: 'autodate2990389176',
+					name: 'created',
+					onCreate: true,
+					onUpdate: false,
+					presentable: false,
+					system: false,
+					type: 'autodate'
+				},
+				{
+					hidden: false,
+					id: 'autodate3332085495',
+					name: 'updated',
+					onCreate: true,
+					onUpdate: true,
+					presentable: false,
+					system: false,
+					type: 'autodate'
+				}
+			],
+			id: 'pbc_1021288652',
+			indexes: [],
+			listRule: '(@request.auth.serverRole != "") || (@collection.site_role_assignments.user.id = @request.auth.id && @collection.site_role_assignments.site.id = site.id)',
+			name: 'site_uploads',
+			system: false,
+			type: 'base',
+			updateRule: '(@request.auth.serverRole != "") || (@collection.site_role_assignments.user.id = @request.auth.id && @collection.site_role_assignments.site.id = id)',
+			viewRule: '(@request.auth.serverRole != "") || (@collection.site_role_assignments.user.id = @request.auth.id && @collection.site_role_assignments.site.id = site.id)'
+		})
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_1021288652')
+
+		return app.delete(collection)
+	}
+)

--- a/pb_migrations/1755961655_created_library_uploads.js
+++ b/pb_migrations/1755961655_created_library_uploads.js
@@ -1,0 +1,74 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = new Collection({
+			createRule: '@request.auth.serverRole != ""',
+			deleteRule: '@request.auth.serverRole != ""',
+			fields: [
+				{
+					autogeneratePattern: '[a-z0-9]{15}',
+					hidden: false,
+					id: 'text3208210256',
+					max: 15,
+					min: 15,
+					name: 'id',
+					pattern: '^[a-z0-9]+$',
+					presentable: false,
+					primaryKey: true,
+					required: true,
+					system: true,
+					type: 'text'
+				},
+				{
+					hidden: false,
+					id: 'file2359244304',
+					maxSelect: 1,
+					maxSize: 0,
+					mimeTypes: [],
+					name: 'file',
+					presentable: false,
+					protected: false,
+					required: true,
+					system: false,
+					thumbs: [],
+					type: 'file'
+				},
+				{
+					hidden: false,
+					id: 'autodate2990389176',
+					name: 'created',
+					onCreate: true,
+					onUpdate: false,
+					presentable: false,
+					system: false,
+					type: 'autodate'
+				},
+				{
+					hidden: false,
+					id: 'autodate3332085495',
+					name: 'updated',
+					onCreate: true,
+					onUpdate: true,
+					presentable: false,
+					system: false,
+					type: 'autodate'
+				}
+			],
+			id: 'pbc_3701780231',
+			indexes: [],
+			listRule: '@request.auth.serverRole != ""',
+			name: 'library_uploads',
+			system: false,
+			type: 'base',
+			updateRule: '@request.auth.serverRole != ""',
+			viewRule: '@request.auth.serverRole != ""'
+		})
+
+		return app.save(collection)
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('pbc_3701780231')
+
+		return app.delete(collection)
+	}
+)


### PR DESCRIPTION
## Changes

- Create SiteUpload and LibraryUpload collections for storing uploaded files
- Fix image field options
- Upload files and preview in image field
- Create image URLs in getContent
- Fix and implement reuploading for CloneSite
- Fix site_context for BlockEditor in library

## Test plan

- [x] Upload image for page section
- [x] Upload image for page type section
- [x] Upload image for site symbol
- [x] Upload image for library symbol
- [ ] Publish site with images
- [ ] Clone site with images (use as starter site when creating a new site)

Resolves #499 