### PR TITLE
Automatically approve PRs from Dependabot related to minor NPM updates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,9 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Enable auto-merge for Dependabot PRs
         if: contains(steps.metadata.outputs.package-ecosystem, 'npm') && steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Now that there's some PRs open from Dependabot and auto-merge allowed, the PRs are not still auto-merged do to missing approval. I previously tried to modify approval rules so that Dependabot PRs wouldn't need approval, but it's not Dependabot that's doing the merging anyway. Actually, I'm not sure what the workflow user is called, because I can't use it to bypass rulesets either. This should work to have the one required approval.