### PR TITLE
Fix auto-merging patch updates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Enable auto-merge for Dependabot PRs
-        if: contains(steps.metadata.outputs.package-ecosystem, 'npm') && steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: >-
+          contains(steps.metadata.outputs.package-ecosystem, 'npm') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
Previously only minor updates from NPM were allowed to be auto-merged. Allow also patch updates from NPM.