### PR TITLE
Fix marketplace blocks and field validation errors

### DIFF
--- a/pb_migrations/1756794121_updated_library_symbol_fields_label_optional.js
+++ b/pb_migrations/1756794121_updated_library_symbol_fields_label_optional.js
@@ -1,0 +1,31 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('library_symbol_fields')
+		if (!collection) {
+			return null
+		}
+
+		// update field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = false
+			return app.save(collection)
+		}
+		return null
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('library_symbol_fields')
+		if (!collection) {
+			return null
+		}
+
+		// revert field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = true
+			return app.save(collection)
+		}
+		return null
+	}
+)

--- a/pb_migrations/1756794122_updated_site_symbol_fields_label_optional.js
+++ b/pb_migrations/1756794122_updated_site_symbol_fields_label_optional.js
@@ -1,0 +1,31 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('site_symbol_fields')
+		if (!collection) {
+			return null
+		}
+
+		// update field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = false
+			return app.save(collection)
+		}
+		return null
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('site_symbol_fields')
+		if (!collection) {
+			return null
+		}
+
+		// revert field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = true
+			return app.save(collection)
+		}
+		return null
+	}
+)

--- a/pb_migrations/1756794123_updated_page_type_fields_label_optional.js
+++ b/pb_migrations/1756794123_updated_page_type_fields_label_optional.js
@@ -1,0 +1,31 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('page_type_fields')
+		if (!collection) {
+			return null
+		}
+
+		// update field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = false
+			return app.save(collection)
+		}
+		return null
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('page_type_fields')
+		if (!collection) {
+			return null
+		}
+
+		// revert field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = true
+			return app.save(collection)
+		}
+		return null
+	}
+)

--- a/pb_migrations/1756794124_updated_site_fields_label_optional.js
+++ b/pb_migrations/1756794124_updated_site_fields_label_optional.js
@@ -1,0 +1,31 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+	(app) => {
+		const collection = app.findCollectionByNameOrId('site_fields')
+		if (!collection) {
+			return null
+		}
+
+		// update field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = false
+			return app.save(collection)
+		}
+		return null
+	},
+	(app) => {
+		const collection = app.findCollectionByNameOrId('site_fields')
+		if (!collection) {
+			return null
+		}
+
+		// revert field
+		const field = collection.fields.getById('text245846248')
+		if (field) {
+			field.required = true
+			return app.save(collection)
+		}
+		return null
+	}
+)

--- a/src/lib/builder/components/Sidebar/PageType_Sidebar.svelte
+++ b/src/lib/builder/components/Sidebar/PageType_Sidebar.svelte
@@ -16,14 +16,15 @@
 	import * as Tabs from '$lib/components/ui/tabs'
 	import { Cuboid, SquarePen, Loader } from 'lucide-svelte'
 	import { page } from '$app/state'
-	import { PageTypes, SiteSymbols, PageTypeSymbols, PageTypeFields, PageTypeEntries, manager } from '$lib/pocketbase/collections'
+	import { PageTypes, SiteSymbols, SiteSymbolFields, SiteSymbolEntries, PageTypeSymbols, PageTypeFields, PageTypeEntries, manager } from '$lib/pocketbase/collections'
+	import { self as pb } from '$lib/pocketbase/PocketBase'
 	import { site_html } from '$lib/builder/stores/app/page.js'
 	import { dragging_symbol } from '$lib/builder/stores/app/misc'
 	import DropZone from '$lib/components/DropZone.svelte'
 	import { Button } from '$lib/components/ui/button'
 	import { setFieldEntries } from '../Fields/FieldsContent.svelte'
 	import { current_user } from '$lib/pocketbase/user.js'
-	import { useImportSiteSymbol } from '$lib/workers/ImportSymbol.svelte.js'
+	import { useImportSiteSymbol } from '$lib/workers/ImportSymbol.svelte.ts'
 	import { site_context, hide_page_field_field_type_context } from '$lib/builder/stores/context'
 	import { tick } from 'svelte'
 	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte.ts'
@@ -217,9 +218,92 @@
 	<Dialog.Content class="z-[999] max-w-[1600px] h-full max-h-[100vh] flex flex-col p-4">
 		<BlockPicker
 			{site}
-			onsave={(blocks) => {
-				console.log({ blocks })
-				// TODO: add blocks to site
+			onsave={async (blocks) => {
+				// Copy library symbols to site symbols
+				for (const library_symbol of blocks) {
+					try {
+						// Create site symbol from library symbol
+						const site_symbol = SiteSymbols.create({
+							name: library_symbol.name,
+							html: library_symbol.html,
+							css: library_symbol.css,
+							js: library_symbol.js,
+							site: site.id
+						})
+						
+						// Get library fields using pb directly to avoid effect context issues
+						const library_fields = await pb.collection('library_symbol_fields').getFullList({
+							filter: `symbol = "${library_symbol.id}"`,
+							sort: 'index'
+						})
+						
+						if (library_fields?.length > 0) {
+							const field_map = new Map()
+							
+							// Create fields in order, handling parent relationships
+							const sorted_fields = [...library_fields].sort((a, b) => {
+								// Fields without parents come first
+								if (!a.parent && b.parent) return -1
+								if (a.parent && !b.parent) return 1
+								return (a.index || 0) - (b.index || 0)
+							})
+							
+							for (const library_field of sorted_fields) {
+								const parent_site_field = library_field.parent ? field_map.get(library_field.parent) : undefined
+								
+								const site_field = SiteSymbolFields.create({
+									key: library_field.key,
+									label: library_field.label,
+									type: library_field.type,
+									config: library_field.config,
+									index: library_field.index,
+									symbol: site_symbol.id,
+									parent: parent_site_field?.id || undefined
+								})
+								field_map.set(library_field.id, site_field)
+							}
+							
+							// Get library entries using pb directly
+							const field_ids = library_fields.map(f => f.id)
+							const library_entries = field_ids.length > 0 ? await pb.collection('library_symbol_entries').getFullList({
+								filter: field_ids.map(id => `field = "${id}"`).join(' || '),
+								sort: 'index'
+							}) : []
+							
+							if (library_entries?.length > 0) {
+								const entry_map = new Map()
+								
+								// Create entries in order, handling parent relationships
+								const sorted_entries = [...library_entries].sort((a, b) => {
+									// Entries without parents come first
+									if (!a.parent && b.parent) return -1
+									if (a.parent && !b.parent) return 1
+									return (a.index || 0) - (b.index || 0)
+								})
+								
+								for (const library_entry of sorted_entries) {
+									const site_field = field_map.get(library_entry.field)
+									const parent_site_entry = library_entry.parent ? entry_map.get(library_entry.parent) : undefined
+									
+									if (site_field) {
+										const site_entry = SiteSymbolEntries.create({
+											field: site_field.id,
+											value: library_entry.value,
+											index: library_entry.index,
+											locale: library_entry.locale,
+											parent: parent_site_entry?.id || undefined
+										})
+										entry_map.set(library_entry.id, site_entry)
+									}
+								}
+							}
+						}
+					} catch (error) {
+						console.error('Error copying library symbol:', error)
+					}
+				}
+				
+				await manager.commit()
 				adding_block = false
 			}}
 		/>

--- a/src/lib/builder/components/Site_Symbol.svelte
+++ b/src/lib/builder/components/Site_Symbol.svelte
@@ -5,27 +5,19 @@
 	import { processCode } from '../utils'
 	import IFrame from '../components/IFrame.svelte'
 	import type { SiteSymbol } from '$lib/common/models/SiteSymbol'
-	import { page } from '$app/state'
-	import { Sites } from '$lib/pocketbase/collections'
 	import type { LibrarySymbol } from '$lib/common/models/LibrarySymbol'
 	import type { Symbol } from '$lib/common/models/Symbol'
 	import { site_context } from '$lib/builder/stores/context'
-	import type { ObjectOf } from '$lib/pocketbase/CollectionMapping.svelte'
+	import { useContent } from '$lib/Content.svelte'
+	import { locale } from '$lib/builder/stores/app/misc'
 
 	let { symbol = $bindable(), checked = false, onclick }: { symbol: SiteSymbol | LibrarySymbol; checked?: boolean; onclick?: () => void } = $props()
 
 	const site = site_context.getOr(null)
+	const _data = $derived(useContent(symbol))
+	const data = $derived(_data && (_data[$locale] ?? {}))
 
 	let name_el
-
-	let renaming = false
-	async function toggle_name_input() {
-		renaming = !renaming
-		// workaround for inability to see cursor when div empty
-		if (symbol.name === '') {
-			symbol.name = 'Block'
-		}
-	}
 
 	let height = $state(0)
 
@@ -33,13 +25,12 @@
 	let component_error = $state()
 	async function compile_component_code(symbol: Symbol) {
 		if (!site) return
-		const data = {} // TODO
 		let res = await processCode({
 			component: {
 				head: site.head,
 				css: symbol.css,
 				html: symbol.html,
-				data: data
+				data
 			},
 			buildStatic: true,
 			hydrated: true

--- a/src/lib/builder/field-types/Number.svelte
+++ b/src/lib/builder/field-types/Number.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <div>
-	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange({ [field.key]: { 0: parseFloat(text) || 0 } })} type="number" />
+	<UI.TextInput {...field} value={entry?.value ?? ''} oninput={(text) => onchange({ [field.key]: { 0: { value: parseFloat(text) || 0 } } })} type="number" />
 </div>
 
 <style lang="postcss">

--- a/src/lib/builder/views/editor/PageType.svelte
+++ b/src/lib/builder/views/editor/PageType.svelte
@@ -456,34 +456,39 @@
 
 	async function copy_symbol_entries_to_section(symbol_id: string, section_id: string) {
 		try {
-			// First get the symbol's fields
-			const symbol_fields = await pb.collection('site_symbol_fields').getFullList({
-				filter: `symbol = "${symbol_id}" && parent = ""`
+			// Get all symbol entries (not just root-level ones)
+			const symbol_entries = await pb.collection('site_symbol_entries').getFullList({
+				filter: `field.symbol = "${symbol_id}"`,
+				expand: 'field',
+				sort: 'index'
 			})
 
-			// Get the field IDs
-			const field_ids = symbol_fields.map((field) => field.id)
-
-			if (field_ids.length === 0) {
+			if (symbol_entries.length === 0) {
 				return
 			}
 
-			// Then get entries for those fields
-			const field_filter = field_ids.map((id) => `field = "${id}"`).join(' || ')
-			const symbol_entries = await pb.collection('site_symbol_entries').getFullList({
-				filter: `(${field_filter}) && parent = ""`
+			const entry_map = new Map()
+			
+			// Sort entries so parent-less entries come first
+			const sorted_entries = [...symbol_entries].sort((a, b) => {
+				if (!a.parent && b.parent) return -1
+				if (a.parent && !b.parent) return 1
+				return (a.index || 0) - (b.index || 0)
 			})
 
-			// Create PageTypeSectionEntries for each root-level entry
-			for (const entry of symbol_entries) {
-				PageTypeSectionEntries.create({
+			// Create entries in order, handling parent relationships
+			for (const entry of sorted_entries) {
+				const parent_section_entry = entry.parent ? entry_map.get(entry.parent) : undefined
+				
+				const section_entry = PageTypeSectionEntries.create({
 					section: section_id,
 					field: entry.field,
 					locale: entry.locale,
 					value: entry.value,
-					index: entry.index
-					// No parent since we're only copying root entries
+					index: entry.index,
+					parent: parent_section_entry?.id || undefined
 				})
+				entry_map.set(entry.id, section_entry)
 			}
 		} catch (error) {
 			console.error('Failed to copy symbol entries:', error)

--- a/src/lib/builder/views/modal/BlockPicker.svelte
+++ b/src/lib/builder/views/modal/BlockPicker.svelte
@@ -9,6 +9,14 @@
 	let { site, onsave } = $props()
 
 	let selected_symbol_group = $state<ObjectOf<typeof LibrarySymbolGroups> | null>(null)
+
+	// Auto-select first group when groups are available
+	$effect(() => {
+		const groups = LibrarySymbolGroups.list() ?? []
+		if (groups.length > 0 && !selected_symbol_group) {
+			selected_symbol_group = groups[0]
+		}
+	})
 	const symbols = $derived(selected_symbol_group?.symbols() ?? [])
 	const columns = $derived(
 		selected_symbol_group

--- a/src/lib/common/models/FieldBase.ts
+++ b/src/lib/common/models/FieldBase.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const FieldBase = z.object({
 	id: z.string().nonempty(),
 	key: z.string(),
-	label: z.string(),
+	label: z.string().optional(),
 	type: z.string().nonempty(),
 	config: z.any().nullable(),
 	parent: z.string().optional(),

--- a/src/lib/components/Masonry.svelte
+++ b/src/lib/components/Masonry.svelte
@@ -1,0 +1,74 @@
+<script lang="ts" generics="T">
+	import type { Snippet } from 'svelte'
+	import { Skeleton } from '$lib/components/ui/skeleton'
+
+	interface Props<T> {
+		items: T[] | undefined
+		columns?: 2 | 3 | 4
+		loading?: boolean
+		skeletonCount?: number
+		children: Snippet<[T]>
+	}
+
+	let { items, columns = 3, loading = false, skeletonCount = 8, children }: Props<T> = $props()
+
+	// Generate random ratios for skeleton cards
+	const skeleton_ratios = $derived(
+		Array.from({ length: columns }, () => 
+			Array.from({ length: Math.ceil(skeletonCount / columns) }, () => 0.5 + Math.random())
+		)
+	)
+
+	// Split items into columns for masonry layout
+	const columnized_items = $derived(
+		items ? Array.from({ length: columns }, (_, i) => 
+			items.filter((_, index) => index % columns === i)
+		) : []
+	)
+</script>
+
+<div class="masonry">
+	{#if loading || items === undefined}
+		{#each skeleton_ratios as column_ratios}
+			<ul>
+				{#each column_ratios as ratio}
+					<li>
+						<Skeleton class="w-full" style="aspect-ratio: {ratio}" />
+					</li>
+				{/each}
+			</ul>
+		{/each}
+	{:else}
+		{#each columnized_items as column}
+			<ul>
+				{#each column as item}
+					<li>
+						{@render children(item)}
+					</li>
+				{/each}
+			</ul>
+		{/each}
+	{/if}
+</div>
+
+<style lang="postcss">
+	.masonry {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: 1fr 1fr;
+
+		@media (min-width: 700px) {
+			grid-template-columns: 1fr 1fr 1fr;
+		}
+
+		@media (min-width: 1200px) {
+			grid-template-columns: 1fr 1fr 1fr 1fr;
+		}
+	}
+
+	ul {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+</style>

--- a/src/lib/components/Masonry.svelte
+++ b/src/lib/components/Masonry.svelte
@@ -4,13 +4,29 @@
 
 	interface Props<T> {
 		items: T[] | undefined
-		columns?: 2 | 3 | 4
 		loading?: boolean
 		skeletonCount?: number
 		children: Snippet<[T]>
 	}
 
-	let { items, columns = 3, loading = false, skeletonCount = 8, children }: Props<T> = $props()
+	let { items, loading = false, skeletonCount = 8, children }: Props<T> = $props()
+
+	// Dynamically determine number of columns based on screen width
+	let window_width = $state(typeof window !== 'undefined' ? window.innerWidth : 1200)
+	
+	$effect(() => {
+		const handle_resize = () => {
+			window_width = window.innerWidth
+		}
+		window.addEventListener('resize', handle_resize)
+		return () => window.removeEventListener('resize', handle_resize)
+	})
+
+	const columns = $derived(
+		window_width < 600 ? 1 :
+		window_width < 700 ? 2 :
+		window_width < 1200 ? 3 : 4
+	)
 
 	// Generate random ratios for skeleton cards
 	const skeleton_ratios = $derived(
@@ -55,7 +71,11 @@
 	.masonry {
 		display: grid;
 		gap: 1rem;
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr;
+
+		@media (min-width: 600px) {
+			grid-template-columns: 1fr 1fr;
+		}
 
 		@media (min-width: 700px) {
 			grid-template-columns: 1fr 1fr 1fr;

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -10,9 +10,9 @@
 	import * as Collapsible from '$lib/components/ui/collapsible'
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
 	import { useSidebar } from '$lib/components/ui/sidebar/index.js'
-	import { marketplace, self } from '$lib/pocketbase/PocketBase'
+	import { self } from '$lib/pocketbase/PocketBase'
 	import type { Component } from 'svelte'
-	import { LibrarySymbolGroups, manager, SiteGroups } from '$lib/pocketbase/collections'
+	import { LibrarySymbolGroups, MarketplaceSymbolGroups, manager, SiteGroups } from '$lib/pocketbase/collections'
 	import { current_user } from '$lib/pocketbase/user'
 
 	const sidebar = useSidebar()
@@ -327,7 +327,7 @@
 								<Collapsible.Content>
 									<Sidebar.GroupContent>
 										<Sidebar.Menu>
-											{#each LibrarySymbolGroups.from(marketplace).list() ?? [] as group}
+											{#each MarketplaceSymbolGroups.list() ?? [] as group}
 												{@const url = `/admin/dashboard/marketplace/blocks?group=${group.id}`}
 												<Sidebar.MenuItem>
 													<Sidebar.MenuButton isActive={$page.url.pathname + $page.url.search === url}>

--- a/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -9,7 +9,7 @@
 <main
 	bind:this={ref}
 	class={cn(
-		'bg-background relative flex min-h-svh flex-1 flex-col',
+		'bg-background relative flex h-svh flex-1 flex-col',
 		'peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
 		className
 	)}

--- a/src/lib/pocketbase/collections.ts
+++ b/src/lib/pocketbase/collections.ts
@@ -61,9 +61,6 @@ export const MarketplaceSymbolGroups = createCollectionMapping('library_symbol_g
 export const MarketplaceSymbols = createCollectionMapping('library_symbols', LibrarySymbol, marketplace_manager, {
 	instance: marketplace,
 	links: {
-		group() {
-			return MarketplaceSymbolGroups.one(this.group)
-		},
 		fields() {
 			return LibrarySymbolFields.from(this.collection.instance).list({ filter: { symbol: this.id } })
 		},

--- a/src/lib/pocketbase/collections.ts
+++ b/src/lib/pocketbase/collections.ts
@@ -25,8 +25,10 @@ import { SiteUpload } from '$lib/common/models/SiteUpload'
 import { User } from '$lib/common/models/User'
 import { createCollectionManager } from './CollectionManager'
 import { createCollectionMapping } from './CollectionMapping.svelte'
+import { marketplace } from './PocketBase'
 
 export const manager = createCollectionManager()
+export const marketplace_manager = createCollectionManager()
 
 export const Users = createCollectionMapping('users', User, manager, {
 	links: {
@@ -43,6 +45,43 @@ export const LibrarySymbolGroups = createCollectionMapping('library_symbol_group
 	links: {
 		symbols() {
 			return LibrarySymbols.from(this.collection.instance).list({ filter: { group: this.id } })
+		}
+	}
+})
+
+export const MarketplaceSymbolGroups = createCollectionMapping('library_symbol_groups', LibrarySymbolGroup, marketplace_manager, {
+	instance: marketplace,
+	links: {
+		symbols() {
+			return MarketplaceSymbols.list({ filter: { group: this.id } })
+		}
+	}
+})
+
+export const MarketplaceSymbols = createCollectionMapping('library_symbols', LibrarySymbol, marketplace_manager, {
+	instance: marketplace,
+	links: {
+		group() {
+			return MarketplaceSymbolGroups.one(this.group)
+		},
+		fields() {
+			return LibrarySymbolFields.from(this.collection.instance).list({ filter: { symbol: this.id } })
+		},
+		entries() {
+			const fields = LibrarySymbolFields.from(this.collection.instance).list({ filter: { symbol: this.id } })
+			if (!fields) {
+				return fields
+			}
+
+			const entries = fields.map((field) => LibrarySymbolEntries.from(this.collection.instance).list({ filter: { field: field.id } }))
+			if (entries.some((entry) => entry === null)) {
+				return null
+			}
+			if (entries.some((entry) => !entry)) {
+				return undefined
+			}
+
+			return entries.filter((entry) => !!entry).flat()
 		}
 	}
 })

--- a/src/routes/dashboard/library/+page.svelte
+++ b/src/routes/dashboard/library/+page.svelte
@@ -10,7 +10,8 @@
 	import { Button } from '$lib/components/ui/button'
 	import EmptyState from '$lib/components/EmptyState.svelte'
 	import DropZone from '$lib/components/DropZone.svelte'
-	import { CirclePlus, Cuboid, Code, Upload, Download, SquarePen, Trash2, ChevronDown, Loader, EllipsisVertical, ArrowLeftRight } from 'lucide-svelte'
+	import Masonry from '$lib/components/Masonry.svelte'
+	import { CirclePlus, Cuboid, Code, Upload, Download, SquarePen, Trash2, ChevronDown, Loader, Loader2, EllipsisVertical, ArrowLeftRight } from 'lucide-svelte'
 	import SymbolButton from '$lib/components/SymbolButton.svelte'
 	import { page } from '$app/state'
 	import { goto } from '$app/navigation'
@@ -274,48 +275,52 @@
 	</div>
 </header>
 
-<div class="flex flex-1 flex-col gap-4 px-4 pb-4">
-	{#if group_symbols.length}
-		<div class="masonry">
-			<ul>
-				{#each group_symbols as symbol (symbol.id)}
-					<li>
-						<SymbolButton {symbol} onclick={() => begin_symbol_edit(symbol)}>
-							<DropdownMenu.Root>
-								<DropdownMenu.Trigger>
-									<EllipsisVertical size={14} />
-								</DropdownMenu.Trigger>
-								<DropdownMenu.Content>
-									<DropdownMenu.Item onclick={() => begin_symbol_edit(symbol)}>
-										<Code class="h-4 w-4" />
-										<span>Edit</span>
-									</DropdownMenu.Item>
-									<DropdownMenu.Item onclick={() => export_symbol(symbol)}>
-										<Download class="h-4 w-4" />
-										<span>Export</span>
-									</DropdownMenu.Item>
-									<DropdownMenu.Item onclick={() => begin_symbol_move(symbol)}>
-										<ArrowLeftRight class="h-4 w-4" />
-										<span>Move</span>
-									</DropdownMenu.Item>
-									<DropdownMenu.Item onclick={() => begin_symbol_rename(symbol)}>
-										<SquarePen class="h-4 w-4" />
-										<span>Rename</span>
-									</DropdownMenu.Item>
-									<DropdownMenu.Item onclick={() => begin_symbol_delete(symbol)} class="text-red-500 hover:text-red-600 focus:text-red-600">
-										<Trash2 class="h-4 w-4" />
-										<span>Delete</span>
-									</DropdownMenu.Item>
-								</DropdownMenu.Content>
-							</DropdownMenu.Root>
-						</SymbolButton>
-					</li>
-				{/each}
-			</ul>
-		</div>
-	{:else}
-		<EmptyState icon={Cuboid} title="No Blocks to display" description="Blocks are components you can add to any site. When you create one it'll show up here." />
-	{/if}
+<div class="flex flex-1 flex-col gap-4 px-4 pb-4 overflow-hidden">
+	{#key active_symbol_group_id}
+		{#if group_symbols === undefined}
+			<!-- Loading state -->
+			<div class="flex flex-col items-center justify-center gap-4 py-8">
+				<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+				<p class="text-sm text-muted-foreground">Loading blocks...</p>
+			</div>
+		{:else if group_symbols.length}
+			<Masonry items={group_symbols}>
+				{#snippet children(symbol)}
+					<SymbolButton {symbol} onclick={() => begin_symbol_edit(symbol)}>
+						<DropdownMenu.Root>
+							<DropdownMenu.Trigger>
+								<EllipsisVertical size={14} />
+							</DropdownMenu.Trigger>
+							<DropdownMenu.Content>
+								<DropdownMenu.Item onclick={() => begin_symbol_edit(symbol)}>
+									<Code class="h-4 w-4" />
+									<span>Edit</span>
+								</DropdownMenu.Item>
+								<DropdownMenu.Item onclick={() => export_symbol(symbol)}>
+									<Download class="h-4 w-4" />
+									<span>Export</span>
+								</DropdownMenu.Item>
+								<DropdownMenu.Item onclick={() => begin_symbol_move(symbol)}>
+									<ArrowLeftRight class="h-4 w-4" />
+									<span>Move</span>
+								</DropdownMenu.Item>
+								<DropdownMenu.Item onclick={() => begin_symbol_rename(symbol)}>
+									<SquarePen class="h-4 w-4" />
+									<span>Rename</span>
+								</DropdownMenu.Item>
+								<DropdownMenu.Item onclick={() => begin_symbol_delete(symbol)} class="text-red-500 hover:text-red-600 focus:text-red-600">
+									<Trash2 class="h-4 w-4" />
+									<span>Delete</span>
+								</DropdownMenu.Item>
+							</DropdownMenu.Content>
+						</DropdownMenu.Root>
+					</SymbolButton>
+				{/snippet}
+			</Masonry>
+		{:else}
+			<EmptyState icon={Cuboid} title="No Blocks to display" description="Blocks are components you can add to any site. When you create one it'll show up here." />
+		{/if}
+	{/key}
 </div>
 
 <!-- Symbol Dialogs -->
@@ -482,21 +487,3 @@
 	</Dialog.Content>
 </Dialog.Root>
 
-<style lang="postcss">
-	.masonry {
-		display: grid;
-		gap: 1rem;
-		/* grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); */
-		grid-template-columns: 1fr 1fr;
-
-		@media (min-width: 700px) {
-			grid-template-columns: 1fr 1fr 1fr;
-		}
-	}
-
-	ul {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-</style>

--- a/src/routes/dashboard/library/+page.svelte
+++ b/src/routes/dashboard/library/+page.svelte
@@ -135,17 +135,18 @@
 	// Symbol rename
 	let symbol_being_renamed: LibrarySymbol | null = $state(null)
 	let is_symbol_renamer_open = $state(false)
+	let symbol_new_name = $state('')
 
 	function begin_symbol_rename(symbol: LibrarySymbol) {
 		symbol_being_renamed = symbol
-		new_name = symbol.name
+		symbol_new_name = symbol.name
 		is_symbol_renamer_open = true
 	}
 
 	async function handle_symbol_rename(e) {
 		e.preventDefault()
 		if (!symbol_being_renamed) return
-		LibrarySymbols.update(symbol_being_renamed.id, { name: new_name })
+		LibrarySymbols.update(symbol_being_renamed.id, { name: symbol_new_name })
 		await manager.commit()
 		is_symbol_renamer_open = false
 		symbol_being_renamed = null
@@ -421,7 +422,7 @@
 		<h2 class="text-lg font-semibold leading-none tracking-tight">Rename Block</h2>
 		<p class="text-muted-foreground text-sm">Enter a new name for your Block</p>
 		<form onsubmit={handle_symbol_rename}>
-			<Input bind:value={new_name} placeholder="Enter new Block name" class="my-4" />
+			<Input bind:value={symbol_new_name} placeholder="Enter new Block name" class="my-4" />
 			<Dialog.Footer>
 				<Button type="button" variant="outline" onclick={() => (is_symbol_renamer_open = false)}>Cancel</Button>
 				<Button type="submit">Rename</Button>


### PR DESCRIPTION
## Summary
- Fixed marketplace blocks not displaying properly
- Fixed validation errors when saving blocks with nested fields

## Changes

### Marketplace Blocks Fix
- Added `MarketplaceSymbolGroups` and `MarketplaceSymbols` collections to properly connect to marketplace API
- Created `Masonry` component for responsive block grid layout  
- Fixed marketplace blocks page to correctly fetch and display blocks
- Added loading states while fetching marketplace data

### Field Validation Fix
- Made label field optional in `FieldBase` schema to allow empty labels during field creation
- Added PocketBase migrations to update field requirements for:
  - library_symbol_fields
  - site_symbol_fields
  - page_type_fields
  - site_fields
- Used collection names instead of IDs in migrations for better maintainability
- Added safety checks to handle non-existent collections/fields

## Test plan
- [ ] Visit marketplace blocks page and verify blocks display correctly
- [ ] Switch between different block groups in marketplace
- [ ] Create a new block in the library
- [ ] Add nested fields to the block (group/repeater fields)
- [ ] Save the block without validation errors
- [ ] Verify migrations run successfully on PocketBase restart