### PR TITLE
Use base36 for output file names

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -5,5 +5,12 @@ export default defineConfig({
 	optimizeDeps: {
 		exclude: ['@rollup/browser']
 	},
+	build: {
+		rollupOptions: {
+			output: {
+				hashCharacters: 'base36'
+			}
+		}
+	},
 	plugins: [sveltekit()]
 })

--- a/common.config.js
+++ b/common.config.js
@@ -7,6 +7,11 @@ export default defineConfig({
 			entry: 'src/lib/common/index.ts',
 			formats: ['cjs'],
 			fileName: 'index'
+		},
+		rollupOptions: {
+			output: {
+				hashCharacters: 'base36'
+			}
 		}
 	}
 })


### PR DESCRIPTION
Previous build failed due to leading undescore. Base36 does not include underscore character. Go build ignores file names with leading underscore.