### PR TITLE
Improve tagging for Docker images

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,6 +33,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
After these changes are merged, releases are automatically tagged like in following examples:

| Git Ref | Docker Tags |
| --- | --- |
| refs/tags/v3.0.0-beta.13 | 3.0.0-beta.13 |
| refs/tags/v3.0.0 | 3.0.0, 3.0, 3, latest |

The changes to Docker image tagging are effectively the following:

- Drop prefix `v` for Docker image tags
- Apply `latest` tag only if the release is not pre-release (aka. it does not include beta, or alpha version numbers)
- Add shorthand tags for locking container to major (eg. `3`) or minor (eg `3.0`) versions

Documentation for docker/metadata-action can be found here: https://github.com/docker/metadata-action

Note that this PR should be merged just before v3.0.0 release if we want to still tag beta versions as latest. Let's keep this as draft until we want to merge it.