### PR TITLE
Dashboard UI: starters, blocks, pricing

### DIFF
--- a/src/lib/components/BlockPickerPanel.svelte
+++ b/src/lib/components/BlockPickerPanel.svelte
@@ -151,7 +151,7 @@
 			<Masonry columnCount={2} class="col-span-3 p-3 pr-0 overflow-scroll" items={active_marketplace_blocks_group_symbols} loading={active_marketplace_blocks_group_symbols === undefined}>
 				{#snippet children(symbol)}
 					<div class="relative">
-						<SymbolButton {symbol} onclick={() => toggle_block(symbol.id, 'marketplace')} />
+						<SymbolButton {symbol} show_price={true} onclick={() => toggle_block(symbol.id, 'marketplace')} />
 						{#if selected.some((block) => block.id === symbol.id)}
 							<div class="pointer-events-none absolute inset-0 bg-[#000000AA] flex items-center justify-center">
 								<Check class="text-primary" />

--- a/src/lib/components/CreateSite.svelte
+++ b/src/lib/components/CreateSite.svelte
@@ -812,7 +812,12 @@
 			{/if}
 		</div>
 		<div class="absolute bottom-0 w-full p-3 z-20 bg-[#000] border-t">
-			<div class="text-sm leading-none truncate">{site.name}</div>
+			<div class="flex items-center gap-2">
+				<div class="text-sm leading-none truncate">{site.name}</div>
+				{#if source === 'marketplace'}
+					<div class="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">Free</div>
+				{/if}
+			</div>
 		</div>
 	</button>
 {/snippet}

--- a/src/lib/components/MarketplaceStarterButton.svelte
+++ b/src/lib/components/MarketplaceStarterButton.svelte
@@ -1,8 +1,6 @@
 <script>
-	import { toast } from 'svelte-sonner'
 	import SitePreview from '$lib/components/SitePreview.svelte'
-	import { CircleCheck, CirclePlus, Loader } from 'lucide-svelte'
-	import { Button } from '$lib/components/ui/button'
+	import { ExternalLink } from 'lucide-svelte'
 	import { Site } from '$lib/common/models/Site'
 
 	/**
@@ -47,40 +45,24 @@
 	$effect(() => {
 		iframe && append_to_iframe(append)
 	})
-
-	let added_to_library = $state([])
-	let loading = $state(false)
-	async function add_to_library() {
-		loading = true
-		// const { data } = await axios.get(`https://weave-marketplace.vercel.app/api/starters/${site.id}`)
-		// TODO: Implement
-		throw new Error('Not implemented')
-		loading = false
-		added_to_library.push(site.id)
-		toast.success('Added Starter to Library')
-	}
 </script>
 
 <svelte:window onresize={resizePreview} />
 
-<div class="space-y-3 relative w-full bg-gray-900">
+<div class="space-y-3 relative w-full aspect-[.69] bg-gray-900">
 	<div class="rounded-tl rounded-tr overflow-hidden">
-		<button class="w-full hover:opacity-75 transition-all" onclick={add_to_library} aria-hidden="true">
-			<SitePreview {site} style="--thumbnail-height: 56.25%" src={`https://palacms.com/?_site=${site.id}`} />
-		</button>
+		<a href={`https://${site.host}`} target="_blank" rel="noopener noreferrer" class="w-full hover:opacity-75 transition-all block">
+			<SitePreview {site} style="--thumbnail-height: 140%" src={`https://${site.host}`} />
+		</a>
 	</div>
 	<div class="absolute -bottom-2 rounded-bl rounded-br w-full p-3 z-20 bg-gray-900 truncate flex items-center justify-between">
-		<div class="text-sm font-medium leading-none hover:underline">{site.name}</div>
-		<Button class="h-4 p-0" onclick={add_to_library} variant="ghost" aria-label="Add to Library">
-			{#if loading}
-				<div class="animate-spin">
-					<Loader />
-				</div>
-			{:else if added_to_library.includes(site.id)}
-				<CircleCheck />
-			{:else}
-				<CirclePlus />
-			{/if}
-		</Button>
+		<div class="flex items-center gap-2">
+			<div class="text-sm font-medium leading-none">{site.name}</div>
+			<div class="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">Free</div>
+		</div>
+		<a href={`https://${site.host}`} target="_blank" rel="noopener noreferrer" class="text-xs text-muted-foreground hover:text-foreground hover:underline flex items-center gap-1">
+			<span>Preview</span>
+			<ExternalLink class="h-3 w-3" />
+		</a>
 	</div>
 </div>

--- a/src/lib/components/SymbolButton.svelte
+++ b/src/lib/components/SymbolButton.svelte
@@ -11,11 +11,13 @@
 	let {
 		symbol,
 		onclick,
-		children = null
+		children = null,
+		show_price = false
 	}: {
 		symbol: ObjectOf<typeof LibrarySymbols>
 		onclick?: () => void
 		children?: null | Snippet
+		show_price?: boolean
 	} = $props()
 
 	const code = $derived(
@@ -43,7 +45,7 @@
 			})
 	})
 
-	const showing_footer = $derived(symbol?.name || children)
+	const showing_footer = $derived(symbol?.name || children || show_price)
 </script>
 
 <div class="relative w-full bg-gray-900 rounded-bl rounded-br">
@@ -52,9 +54,14 @@
 	</button>
 	{#if showing_footer}
 		<div class="w-full p-3 pt-2 bg-gray-900 truncate flex items-center justify-between">
-			{#if symbol?.name}
-				<div class="text-xs leading-none truncate" style="width: calc(100% - 2rem)">{symbol?.name}</div>
-			{/if}
+			<div class="flex items-center gap-2" style="width: calc(100% - 2rem)">
+				{#if symbol?.name}
+					<div class="text-xs leading-none truncate">{symbol?.name}</div>
+				{/if}
+				{#if show_price}
+					<div class="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium">Free</div>
+				{/if}
+			</div>
 			{#if children}
 				<div>
 					{@render children()}

--- a/src/routes/dashboard/library/+page.svelte
+++ b/src/routes/dashboard/library/+page.svelte
@@ -11,7 +11,26 @@
 	import EmptyState from '$lib/components/EmptyState.svelte'
 	import DropZone from '$lib/components/DropZone.svelte'
 	import Masonry from '$lib/components/Masonry.svelte'
-	import { CirclePlus, Cuboid, Code, Upload, Download, SquarePen, Trash2, ChevronDown, Loader, Loader2, EllipsisVertical, ArrowLeftRight } from 'lucide-svelte'
+	import {
+		CirclePlus,
+		Cuboid,
+		Code,
+		Upload,
+		Download,
+		SquarePen,
+		Trash2,
+		ChevronDown,
+		Loader,
+		Loader2,
+		EllipsisVertical,
+		ArrowLeftRight,
+		Info,
+		Plus,
+		MousePointer,
+		Edit3,
+		Share,
+		Store
+	} from 'lucide-svelte'
 	import SymbolButton from '$lib/components/SymbolButton.svelte'
 	import { page } from '$app/state'
 	import { goto } from '$app/navigation'
@@ -44,9 +63,18 @@
 	const sidebar = useSidebar()
 
 	let creating_block = $state(false)
+	let is_info_dialog_open = $state(false)
 
 	function open_create_block() {
 		creating_block = true
+	}
+
+	async function create_first_group() {
+		const group = LibrarySymbolGroups.create({ name: 'Default', index: 0 })
+		await manager.commit()
+		const url = new URL(page.url)
+		url.searchParams.set('group', group.id)
+		goto(url, { replaceState: true })
 	}
 
 	let file = $state<File>()
@@ -263,6 +291,9 @@
 		</DropdownMenu.Root>
 	</div>
 	<div class="ml-auto mr-4 flex gap-2">
+		<Button size="sm" variant="ghost" onclick={() => (is_info_dialog_open = true)}>
+			<Info class="h-4 w-4" />
+		</Button>
 		{#if active_symbol_group_id}
 			<Button size="sm" variant="outline" onclick={open_create_block}>
 				<CirclePlus class="h-4 w-4" />
@@ -277,51 +308,84 @@
 </header>
 
 <div class="flex flex-1 flex-col gap-4 px-4 pb-4 overflow-hidden">
-	{#key active_symbol_group_id}
-		{#if group_symbols === undefined}
-			<!-- Loading state -->
-			<div class="flex flex-col items-center justify-center gap-4 py-8">
-				<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
-				<p class="text-sm text-muted-foreground">Loading blocks...</p>
-			</div>
-		{:else if group_symbols.length}
-			<Masonry items={group_symbols}>
-				{#snippet children(symbol)}
-					<SymbolButton {symbol} onclick={() => begin_symbol_edit(symbol)}>
-						<DropdownMenu.Root>
-							<DropdownMenu.Trigger>
-								<EllipsisVertical size={14} />
-							</DropdownMenu.Trigger>
-							<DropdownMenu.Content>
-								<DropdownMenu.Item onclick={() => begin_symbol_edit(symbol)}>
-									<Code class="h-4 w-4" />
-									<span>Edit</span>
-								</DropdownMenu.Item>
-								<DropdownMenu.Item onclick={() => export_symbol(symbol)}>
-									<Download class="h-4 w-4" />
-									<span>Export</span>
-								</DropdownMenu.Item>
-								<DropdownMenu.Item onclick={() => begin_symbol_move(symbol)}>
-									<ArrowLeftRight class="h-4 w-4" />
-									<span>Move</span>
-								</DropdownMenu.Item>
-								<DropdownMenu.Item onclick={() => begin_symbol_rename(symbol)}>
-									<SquarePen class="h-4 w-4" />
-									<span>Rename</span>
-								</DropdownMenu.Item>
-								<DropdownMenu.Item onclick={() => begin_symbol_delete(symbol)} class="text-red-500 hover:text-red-600 focus:text-red-600">
-									<Trash2 class="h-4 w-4" />
-									<span>Delete</span>
-								</DropdownMenu.Item>
-							</DropdownMenu.Content>
-						</DropdownMenu.Root>
-					</SymbolButton>
-				{/snippet}
-			</Masonry>
-		{:else}
-			<EmptyState class="h-[50vh]" icon={Cuboid} title="No Blocks to display" description="Blocks are components you can add to any site. When you create one it'll show up here." />
-		{/if}
-	{/key}
+	{#if symbol_groups.length === 0}
+		<!-- No groups exist -->
+		<EmptyState
+			class="h-[50vh]"
+			icon={Cuboid}
+			title="No Block Groups"
+			description="Create your first block group to start organizing your components."
+			button={{
+				label: 'Create First Group',
+				icon: CirclePlus,
+				onclick: create_first_group
+			}}
+		/>
+	{:else}
+		{#key active_symbol_group_id}
+			{#if group_symbols === undefined}
+				<!-- Loading state -->
+				<div class="flex flex-col items-center justify-center gap-4 py-8">
+					<Loader2 class="h-8 w-8 animate-spin text-muted-foreground" />
+					<p class="text-sm text-muted-foreground">Loading blocks...</p>
+				</div>
+			{:else if group_symbols.length}
+				<Masonry items={group_symbols}>
+					{#snippet children(symbol)}
+						<SymbolButton {symbol} onclick={() => begin_symbol_edit(symbol)}>
+							<DropdownMenu.Root>
+								<DropdownMenu.Trigger>
+									<EllipsisVertical size={14} />
+								</DropdownMenu.Trigger>
+								<DropdownMenu.Content>
+									<DropdownMenu.Item onclick={() => begin_symbol_edit(symbol)}>
+										<Code class="h-4 w-4" />
+										<span>Edit</span>
+									</DropdownMenu.Item>
+									<DropdownMenu.Item onclick={() => export_symbol(symbol)}>
+										<Download class="h-4 w-4" />
+										<span>Export</span>
+									</DropdownMenu.Item>
+									<DropdownMenu.Item onclick={() => begin_symbol_move(symbol)}>
+										<ArrowLeftRight class="h-4 w-4" />
+										<span>Move</span>
+									</DropdownMenu.Item>
+									<DropdownMenu.Item onclick={() => begin_symbol_rename(symbol)}>
+										<SquarePen class="h-4 w-4" />
+										<span>Rename</span>
+									</DropdownMenu.Item>
+									<DropdownMenu.Item onclick={() => begin_symbol_delete(symbol)} class="text-red-500 hover:text-red-600 focus:text-red-600">
+										<Trash2 class="h-4 w-4" />
+										<span>Delete</span>
+									</DropdownMenu.Item>
+								</DropdownMenu.Content>
+							</DropdownMenu.Root>
+						</SymbolButton>
+					{/snippet}
+				</Masonry>
+			{:else}
+				<div class="flex flex-col items-center justify-center gap-6 flex-1 h-[50vh]">
+					<div class="flex items-center justify-center w-20 h-20 bg-gray-100 rounded-full dark:bg-gray-800">
+						<Cuboid class="w-10 h-10 text-gray-500 dark:text-gray-400" />
+					</div>
+					<div class="space-y-2 text-center">
+						<h2 class="text-2xl font-bold tracking-tight">No Blocks to display</h2>
+						<p class="text-gray-500 dark:text-gray-400 text-balance max-w-[30rem]">Blocks are components you can add to any site. When you create one it'll show up here.</p>
+					</div>
+					<div class="flex gap-3">
+						<Button onclick={open_create_block} variant="outline">
+							<CirclePlus class="h-4 w-4" />
+							<span>Create Block</span>
+						</Button>
+						<Button onclick={() => goto('/admin/dashboard/marketplace/blocks')} variant="outline">
+							<Store class="h-4 w-4" />
+							<span>Browse Marketplace</span>
+						</Button>
+					</div>
+				</div>
+			{/if}
+		{/key}
+	{/if}
 </div>
 
 <!-- Symbol Dialogs -->
@@ -484,6 +548,59 @@
 			>
 				Cancel
 			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root bind:open={is_info_dialog_open}>
+	<Dialog.Content class="sm:max-w-[525px] pt-12 gap-0">
+		<h2 class="text-lg font-semibold leading-none tracking-tight">How Blocks Work in Pala</h2>
+		<p class="text-muted-foreground text-sm mb-6">Blocks are reusable components that you can add to any page on your sites.</p>
+
+		<div class="space-y-4">
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<Plus class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Create or Import Blocks</h3>
+					<p class="text-muted-foreground text-sm">Build custom blocks using the visual editor or import blocks from other sites. Organize them into groups for easy management.</p>
+				</div>
+			</div>
+
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<MousePointer class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Add Blocks to Pages</h3>
+					<p class="text-muted-foreground text-sm">When editing a page, drag blocks from the sidebar into your page layout. Blocks can be positioned anywhere and customized with different content.</p>
+				</div>
+			</div>
+
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<Edit3 class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Customize Content</h3>
+					<p class="text-muted-foreground text-sm">Each block can have different content on different pages. Edit text, images, and other content directly in the page editor.</p>
+				</div>
+			</div>
+
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<Share class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Reuse Across Sites</h3>
+					<p class="text-muted-foreground text-sm">Export blocks to share with other sites or import blocks from the marketplace to expand your component library.</p>
+				</div>
+			</div>
+		</div>
+
+		<Dialog.Footer class="mt-6">
+			<Button type="button" onclick={() => (is_info_dialog_open = false)}>Got it</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/routes/dashboard/marketplace/starters/+page.svelte
+++ b/src/routes/dashboard/marketplace/starters/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import * as Sidebar from '$lib/components/ui/sidebar'
+	import * as Dialog from '$lib/components/ui/dialog'
 	import { Separator } from '$lib/components/ui/separator'
 	import EmptyState from '$lib/components/EmptyState.svelte'
-	import { LayoutTemplate } from 'lucide-svelte'
+	import { LayoutTemplate, Info, Globe, ExternalLink, SquarePen, CheckCircle } from 'lucide-svelte'
 	import MarketplaceStarterButton from '$lib/components/MarketplaceStarterButton.svelte'
+	import { Button } from '$lib/components/ui/button'
 	import { page } from '$app/state'
 	import { MarketplaceSiteGroups, MarketplaceSites } from '$lib/pocketbase/collections'
 	import { Skeleton } from '$lib/components/ui/skeleton'
@@ -11,6 +13,8 @@
 
 	const group_id = $derived(page.url.searchParams.get('group') ?? undefined)
 	const starters = $derived(group_id ? (MarketplaceSites.list({ filter: { group: group_id }, sort: 'index' }) ?? undefined) : undefined)
+
+	let is_info_dialog_open = $state(false)
 
 	// Auto-select first group if none is selected
 	$effect(() => {
@@ -28,6 +32,12 @@
 		<Sidebar.Trigger />
 		<Separator orientation="vertical" class="mr-2 h-4" />
 		<div class="text-sm">Starter Sites</div>
+	</div>
+	<div class="ml-auto mr-4">
+		<Button size="sm" variant="outline" onclick={() => (is_info_dialog_open = true)}>
+			<Info class="h-4 w-4" />
+			How to Use Starters
+		</Button>
 	</div>
 </header>
 <div class="flex flex-1 flex-col gap-4 px-4 pb-4">
@@ -49,3 +59,58 @@
 		{/if}
 	{/key}
 </div>
+
+<Dialog.Root bind:open={is_info_dialog_open}>
+	<Dialog.Content class="sm:max-w-[525px] pt-12 gap-0">
+		<h2 class="text-lg font-semibold leading-none tracking-tight">How to Use Starter Sites</h2>
+		<p class="text-muted-foreground text-sm mb-6">Follow these steps to create a new site using a starter:</p>
+
+		<div class="space-y-4">
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<Globe class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Connect a new domain name to the server</h3>
+					<p class="text-muted-foreground text-sm">Point your domain's DNS records to this server or configure your hosting provider to route traffic here.</p>
+				</div>
+			</div>
+
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<ExternalLink class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Access the server from that domain name</h3>
+					<p class="text-muted-foreground text-sm">Once the domain is connected, visit your new domain in a web browser. You'll be prompted to create a new site automatically.</p>
+				</div>
+			</div>
+
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<LayoutTemplate class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Choose a starter site</h3>
+					<p class="text-muted-foreground text-sm">
+						During the site creation process, you can select one of these starter sites as a starting point for your new site. The starter will be cloned and customized for your domain.
+					</p>
+				</div>
+			</div>
+
+			<div class="flex gap-4">
+				<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center">
+					<SquarePen class="w-3 h-3" />
+				</div>
+				<div>
+					<h3 class="font-medium text-sm mb-1">Customize your site</h3>
+					<p class="text-muted-foreground text-sm">After creation, you can edit the content, design, and functionality of your site using the built-in editor.</p>
+				</div>
+			</div>
+		</div>
+
+		<Dialog.Footer class="mt-6">
+			<Button type="button" onclick={() => (is_info_dialog_open = false)}>Got it</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>


### PR DESCRIPTION
Changes
- Marketplace Previews: Added preview links for marketplace starters with hover states
- Pricing Display: Added "Free" badges to marketplace starters and blocks
- UI Cleanup: Hide footers for library blocks without titles, removed redundant buttons
- User Guidance: Added info dialogs explaining how starters and blocks work
- Empty States: Added helpful buttons for creating first groups and browsing marketplace