### PR TITLE
Enable compression for palacms.com deployments

### DIFF
--- a/deployment/production/compose.yaml
+++ b/deployment/production/compose.yaml
@@ -17,12 +17,14 @@ services:
       - traefik.http.routers.production-palacms-http.rule=Host(`palacms.com`) || Host(`marketplace.palacms.com`) || HostRegexp(`^.+\.palacms.site$`)
 
       - traefik.http.routers.production-palacms-https.entrypoints=https
+      - traefik.http.routers.production-palacms-https.middlewares=compress
       - traefik.http.routers.production-palacms-https.rule=Host(`palacms.com`)
       - traefik.http.routers.production-palacms-https.service=production-palacms
       - traefik.http.routers.production-palacms-https.tls=true
       - traefik.http.routers.production-palacms-https.tls.certresolver=palacms
 
       - traefik.http.routers.starter-palacms-https.entrypoints=https
+      - traefik.http.routers.starter-palacms-https.middlewares=compress
       - traefik.http.routers.starter-palacms-https.rule=HostRegexp(`^.+\.palacms.site$`)
       - traefik.http.routers.starter-palacms-https.service=production-palacms
       - traefik.http.routers.starter-palacms-https.tls=true
@@ -38,6 +40,7 @@ services:
       - traefik.http.routers.marketplace-palacms-https.middlewares=marketplace-palacms-redirect
 
       - traefik.http.routers.marketplace-palacms-https-api.entrypoints=https
+      - traefik.http.routers.marketplace-palacms-https-api.middlewares=compress
       - traefik.http.routers.marketplace-palacms-https-api.rule=Host(`marketplace.palacms.com`) && PathPrefix(`/api`)
       - traefik.http.routers.marketplace-palacms-https-api.service=production-palacms
       - traefik.http.routers.marketplace-palacms-https-api.tls=true

--- a/deployment/testing/compose.yaml
+++ b/deployment/testing/compose.yaml
@@ -16,6 +16,7 @@ services:
       - traefik.http.routers.testing-palacms-http.middlewares=https-redirect
       - traefik.http.routers.testing-palacms-http.rule=Host(`testing.palacms.com`)
       - traefik.http.routers.testing-palacms-https.entrypoints=https
+      - traefik.http.routers.testing-palacms-https.middlewares=compress
       - traefik.http.routers.testing-palacms-https.rule=Host(`testing.palacms.com`)
       - traefik.http.routers.testing-palacms-https.service=testing-palacms
       - traefik.http.routers.testing-palacms-https.tls=true


### PR DESCRIPTION
Enable compression for all palacms.com routers excluding routers which only do redirection. The change is already appied for the currently active deployments, but this PR needs to be merged in order to persist the change. `compress` middleware is made available in the Traefik deployment which is not part of this repository.