### PR TITLE
Ensure that user avatar field exists

### DIFF
--- a/migrations/1761041200_ensure_avatar.go
+++ b/migrations/1761041200_ensure_avatar.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(
+		func(app core.App) error {
+			users, err := app.FindCollectionByNameOrId("users")
+			if err != nil {
+				return err
+			}
+
+			avatar := users.Fields.GetByName("avatar")
+			if avatar == nil {
+				users.Fields.Add(&core.FileField{
+					Name: "avatar",
+					MimeTypes: []string{
+						"image/jpeg",
+						"image/png",
+						"image/svg+xml",
+						"image/gif",
+						"image/webp",
+					},
+				})
+				if err := app.Save(users); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		func(app core.App) error {
+			return nil
+		},
+	)
+}


### PR DESCRIPTION
Collaborator view was added in #754 and depends on avatar field. For some reason avatar field does not exist on currently existing servers. The new migration ensures avatar field exists before running migration for collaborator view. This should be merged before any release is done.