### PR TITLE
Fix error when inviting collaborator

### DIFF
--- a/src/lib/builder/views/modal/Collaboration.svelte
+++ b/src/lib/builder/views/modal/Collaboration.svelte
@@ -156,10 +156,20 @@
 	let users = $derived(Collaborators.list())
 	let server_members = $derived(users?.filter(({ serverRole }) => !!serverRole))
 	let site_collborators = $derived(
-		site.role_assignments()?.map((assignment) => ({
-			assignment,
-			user: users?.find((user) => user.id === assignment.user)!
-		}))
+		site
+			.role_assignments()
+			?.map((assignment) => ({
+				assignment,
+				user: users?.find((user) => user.id === assignment.user)
+			}))
+			.filter(
+				(
+					collaborator
+				): collaborator is {
+					assignment: ObjectOf<typeof SiteRoleAssignments>
+					user: ObjectOf<typeof Collaborators>
+				} => !!collaborator.user
+			)
 	)
 	let is_remove_collaborator_open = $state(false)
 	let removing_collaborator = $state(false)


### PR DESCRIPTION
When new user is created, the user might not be immidiately available in local collaborators collection (view). Actually it is not updated in real time at all for some reason. This PR fixes the error, but new user won't be visible without refresh because of the underlying issue which might be related to the collection being of type "view". That undelying issue should be fixed in a separate PR so that we get this fixed to allow invitation link to be shown at all.