### PR TITLE
Allow triggering deploy to testing manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Build Docker image and deploy testing
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Merging this should allow running the workflow by clicking a button. This enables us for example to test PRs in real server. See more about the feature from link below.

https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow