### PR TITLE
Fix hanging if other commands than serve are used

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -35,13 +35,17 @@ func cleanupUserActivity(pb *pocketbase.PocketBase) error {
 }
 
 func RegisterUserActivity(pb *pocketbase.PocketBase) error {
-	terminated := make(chan bool)
+	var terminated chan bool
 	pb.OnTerminate().BindFunc(func(terminateEvent *core.TerminateEvent) error {
-		terminated <- true
+		if terminated != nil {
+			terminated <- true
+		}
 		return terminateEvent.Next()
 	})
 
 	pb.OnServe().BindFunc(func(serveEvent *core.ServeEvent) error {
+		terminated := make(chan bool)
+
 		// Spawn goroutine for cleanup
 		go func() {
 			ticker := time.NewTicker(userActivityCleanupInterval)


### PR DESCRIPTION
PalaCMS CLI (inherited from PocketBase) has other commands than starting the server. If other commands are used, such as `palacms --help`, the process hangs and does not exit. It should normally exit with exit code 0.

This PR fixes the hanging issue by making sure that user activity feature does not send a signal to a channel that is not being listened. In Golang, a non-buffered channel will block until the channel has been read. In the fix, we make sure not to create the `terminated` channel until serve has been called, to ensure that it is always read when it's being written into.