### PR TITLE
Handle multiple site collaborators with updated API rules

### DIFF
--- a/migrations/1763250053_fix_api_rules.go
+++ b/migrations/1763250053_fix_api_rules.go
@@ -8,6 +8,10 @@ import (
 )
 
 func init() {
+	strPtr := func(s string) *string {
+		return &s
+	}
+
 	m.Register(
 		func(app core.App) error {
 			type apiRuleUpdateSpec struct {
@@ -56,15 +60,15 @@ func init() {
 				baseRule := fmt.Sprintf(baseRuleTemplate, "", spec.SiteIDField)
 				modifyRule := fmt.Sprintf(baseRuleTemplate, modifyPrefix, spec.SiteIDField)
 
-				collection.ViewRule = &baseRule
-				collection.ListRule = &baseRule
-				collection.CreateRule = &modifyRule
-				collection.UpdateRule = &modifyRule
-				collection.DeleteRule = &baseRule
+				collection.ViewRule = strPtr(baseRule)
+				collection.ListRule = strPtr(baseRule)
+				collection.CreateRule = strPtr(modifyRule)
+				collection.UpdateRule = strPtr(modifyRule)
+				collection.DeleteRule = strPtr(baseRule)
 
 				if spec.OwnedByUser {
-					collection.UpdateRule = &ownerRule
-					collection.DeleteRule = &ownerRule
+					collection.UpdateRule = strPtr(ownerRule)
+					collection.DeleteRule = strPtr(ownerRule)
 				}
 
 				if spec.Immutable {


### PR DESCRIPTION
Use "any/at least one of equal" operator (?=) instead of "equal" operator (=) to match the current user to a site role assignment, allowing multiple records to exist in site_role_assignments.

The change to API rules can be summarized to:

```diff
- @collection.site_role_assignments.user.id = @request.auth.id && @collection.site_role_assignments.site.id = site.id
+ @collection.site_role_assignments.user.id ?= @request.auth.id && @collection.site_role_assignments.site.id ?= site.id
```

Fixes #795

## Testing Plan

- [ ] Ensure migration runs successfully and all relevant collections are updated
- [ ] Ensure multiple site collaborators can edit the same site
- [ ] Ensure that site collaborator that has access to multiple sites can edit all of them

## Notes 

- Marketplace has custom API rules and they need to be reapplied after this migration overwrites them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API access-control rules across multiple collections to enforce ownership and immutability consistently.
  * Ensured view, list, create, update, and delete permissions reflect ownership and immutable flags, preventing unauthorized updates or deletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->