### PR TITLE
Fix image loading from site field

### DIFF
--- a/src/lib/Content.svelte.ts
+++ b/src/lib/Content.svelte.ts
@@ -351,12 +351,13 @@ export const useContent = <Collection extends keyof typeof ENTITY_COLLECTIONS>(e
 				const upload_id: string | null | undefined = entry.value.upload
 				const upload = upload_id ? uploads.find((upload) => upload.id === upload_id) : null
 
+				const is_library_symbol = 'group' in entity && 'html' in entity
 				const upload_url =
 					upload &&
 					(options.target === 'live'
 						? `/_uploads/${upload.file}`
 						: typeof upload.file === 'string'
-							? `${self.instance?.baseURL}/api/files/${'group' in entity ? 'library_uploads' : 'site_uploads'}/${upload.id}/${upload.file}`
+							? `${self.instance?.baseURL}/api/files/${is_library_symbol ? 'library_uploads' : 'site_uploads'}/${upload.id}/${upload.file}`
 							: URL.createObjectURL(upload.file))
 				const input_url: string | undefined = entry.value.url
 				const url = input_url || upload_url


### PR DESCRIPTION
Image field as site field referenced by symbol field did not load the image in CMS, but when page is published it loads fine. It was trying to load it from library_uploads instead of site_uploads because site was being recognized as library symbol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the classification system that determines whether content should be processed as library or site resources, improving accuracy when routing uploads to their appropriate storage destinations.
  * Streamlined image field output by removing width and height dimension values while preserving essential metadata including alt text and URL for better data clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->