### PR TITLE
Fix workflow for deploing to production server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Deploy to server
         env:
           DOCKER_HOST: ${{ secrets.TESTING_DOCKER_HOST }}
-          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ jobs.build-image.outputs.version }}
+          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-image.outputs.version }}
         run: |
           cd ./deployment/testing/
           eval "$(ssh-agent -s)"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Deploy to server
         env:
           DOCKER_HOST: ${{ secrets.PRODUCTION_DOCKER_HOST }}
-          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ jobs.build-image.outputs.version }}
+          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-image.outputs.version }}
         run: |
           cd ./deployment/production/
           eval "$(ssh-agent -s)"


### PR DESCRIPTION
In both workflows, use the built image version when deploying it to server instead of Git refs. This should fix automatic deployment to production server (aka. palacms.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now exposes a canonical version used for image tagging.
  * Deployment jobs now consume that standardized version, unifying staging and production image tags for more consistent, reliable releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->