### PR TITLE
Change batch size 50 -> 20

### DIFF
--- a/migrations/1766389971_adjust_batch_size.go
+++ b/migrations/1766389971_adjust_batch_size.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(
+		func(app core.App) error {
+			settings := app.Settings()
+			if settings.Batch.MaxRequests != 50 {
+				// Not using default batch size, leave it unchanged
+				return nil
+			}
+
+			// Set batch size to 20 requests/batch
+			settings.Batch.MaxRequests = 20
+			return app.Save(settings)
+		},
+		func(app core.App) error {
+			return nil
+		},
+	)
+}


### PR DESCRIPTION
Add migration to change batch size to a confortable value of 20 requests/batch. Only change the batch size if it has not been altered already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * The default batch size for request processing has been adjusted from 50 to 20 requests per batch. This configuration change applies automatically upon the next application launch. The adjustment modifies how the application processes requests in batches, resulting in smaller batch operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->