### PR TITLE
Pala → Primo rename, phase 1 (cosmetic, reversible)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            PALA_VERSION=${{ github.head_ref || github.ref_name }}
+            PRIMO_VERSION=${{ github.head_ref || github.ref_name }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -56,7 +56,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            PALA_VERSION=${{ github.head_ref || github.ref_name }}
+            PRIMO_VERSION=${{ github.head_ref || github.ref_name }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to Pala
+# Contributing to Primo
 
-Thank you for your interest in contributing to Pala! In the interest of full transparency, we want to be up front in this doc to avoid hurting feelings and set clear expectations.
+Thank you for your interest in contributing to Primo! In the interest of full transparency, we want to be up front in this doc to avoid hurting feelings and set clear expectations.
 
-## About Pala
+## About Primo
 
-Pala is a business-driven open source project (think NextJS, Supabase, Tailwind CSS) rather than a community-driven one like Linux or Apache. We're building a sustainable business around a high-quality open source tool, which means:
+Primo is a business-driven open source project (think NextJS, Supabase, Tailwind CSS) rather than a community-driven one like Linux or Apache. We're building a sustainable business around a high-quality open source tool, which means:
 
 - We maintain control over project direction
 - We have limited bandwidth for reviewing external contributions
@@ -35,7 +35,7 @@ For detailed technical information including architecture, development setup, an
 
 ## 🔄 If You Want to Contribute
 
-We genuinely appreciate contributions! However, since Pala serves a broad range of users and use cases, we need to be thoughtful about changes to protect the project's general-purpose nature and long-term vision.
+We genuinely appreciate contributions! However, since Primo serves a broad range of users and use cases, we need to be thoughtful about changes to protect the project's general-purpose nature and long-term vision.
 
 ### Step 1: Discuss First
 
@@ -82,9 +82,9 @@ If you've received approval to proceed:
 - Changes that increase complexity significantly
 - Features that duplicate existing functionality
 
-## 🤝 Forking Pala
+## 🤝 Forking Primo
 
-If you want to create your own version of Pala:
+If you want to create your own version of Primo:
 
 1. **Fork freely** - The codebase is open source for a reason
 2. **No approval needed** - Make whatever changes you want in your fork
@@ -101,15 +101,15 @@ If you want to create your own version of Pala:
 
 ## 📄 License
 
-Pala is MIT licensed, which means:
+Primo is MIT licensed, which means:
 
-- **You can build proprietary products** on top of Pala without sharing your code
+- **You can build proprietary products** on top of Primo without sharing your code
 - **You can fork and modify** without contributing back
 - **You can use it commercially** without restrictions
-- **Any code you contribute** to the main Pala repository will be MIT licensed
+- **Any code you contribute** to the main Primo repository will be MIT licensed
 
-By contributing to Pala, you agree that your contributions will be licensed under the MIT License.
+By contributing to Primo, you agree that your contributions will be licensed under the MIT License.
 
 ---
 
-**Thank you for your interest in Pala!** Whether you're forking for your own use or contributing back, we appreciate you and hope the code serves you well.
+**Thank you for your interest in Primo!** Whether you're forking for your own use or contributing back, we appreciate you and hope the code serves you well.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,8 +1,8 @@
 # Developer Guide
 
-This guide covers the technical aspects of working **on the Pala codebase itself** - whether you're contributing, forking, or just trying to understand how it works.
+This guide covers the technical aspects of working **on the Primo codebase itself** - whether you're contributing, forking, or just trying to understand how it works.
 
-> **Looking to build with Pala?** If you want to learn how to create blocks, templates, or sites using Pala, check out our user documentation at [palacms.com/docs](https://palacms.com/docs).
+> **Looking to build with Primo?** If you want to learn how to create blocks, templates, or sites using Primo, check out our user documentation at [palacms.com/docs](https://palacms.com/docs).
 
 ## 🏗️ Architecture Overview
 
@@ -234,11 +234,11 @@ docker build -t palacms .
 The app uses these environment variables during the initial start to optionally create up to two initial users:
 
 - For initial superuser:
-  - PALA_SUPERUSER_EMAIL
-  - PALA_SUPERUSER_PASSWORD
-- For initial Pala user:
-  - PALA_USER_EMAIL
-  - PALA_USER_PASSWORD
+  - PRIMO_SUPERUSER_EMAIL (or legacy PALA_SUPERUSER_EMAIL)
+  - PRIMO_SUPERUSER_PASSWORD (or legacy PALA_SUPERUSER_PASSWORD)
+- For initial Primo user:
+  - PRIMO_USER_EMAIL (or legacy PALA_USER_EMAIL)
+  - PRIMO_USER_PASSWORD (or legacy PALA_USER_PASSWORD)
 
 The container requires volume to be mounted on path `/app/pb_data` for storing files and a SQLite database.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS go-builder
 # These arguments can be overridden on build
 ARG TARGETOS
 ARG TARGETARCH
-ARG PALA_VERSION
+ARG PRIMO_VERSION
 
 # Copy all the files that are not in .dockerignore
 COPY . /app
@@ -29,15 +29,15 @@ COPY --from=node-builder /app/internal/common /app/internal/common
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
   go build -o palacms -ldflags "\
     -X 'github.com/palacms/palacms/internal.buildTime=$(date --utc -Iseconds)'\
-    -X 'github.com/palacms/palacms/internal.buildVersion=$PALA_VERSION'\
+    -X 'github.com/palacms/palacms/internal.buildVersion=$PRIMO_VERSION'\
   "
 
 FROM alpine:3 AS runtime
 
-ENV PALA_SUPERUSER_EMAIL=
-ENV PALA_SUPERUSER_PASSWORD=
-ENV PALA_USER_EMAIL=
-ENV PALA_USER_PASSWORD=
+ENV PRIMO_SUPERUSER_EMAIL=
+ENV PRIMO_SUPERUSER_PASSWORD=
+ENV PRIMO_USER_EMAIL=
+ENV PRIMO_USER_PASSWORD=
 
 # Copy build executable
 COPY --from=go-builder /app/palacms /app/palacms

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-This document describes the security policy for PalaCMS.
+This document describes the security policy for Primo CMS.
 
 ## Supported Versions
 
@@ -11,19 +11,19 @@ This document describes the security policy for PalaCMS.
 
 ## Reporting a Vulnerability
 
-1. When you find a vulnerability related to PalaCMS, report them via email to
+1. When you find a vulnerability related to Primo CMS, report them via email to
    security@palacms.com. Do not send the information anywhere else. Note that
    issues section is not the place for vulnerabilities.
 
-2. PalaCMS team reviews the report in one full week and gets back to you with
+2. The Primo team reviews the report in one full week and gets back to you with
    instructions on how to proceed.
 
 3. You must keep vulnerability as a secret until it has been patched and you
-   have received a written permission from PalaCMS team to publicly disclose
+   have received a written permission from the Primo team to publicly disclose
    the vulnerability. The permission will be sent from email address attached
    to palacms.com domain name.
 
-4. To ensure that PalaCMS team keeps the software secure and its users safe,
+4. To ensure that the Primo team keeps the software secure and its users safe,
    you may provide a deadline for the vulnerability disclosure. The deadline
    must be at least 90 days and should follow established practices on security
    research and vulnerability disclosure.

--- a/devenv.nix
+++ b/devenv.nix
@@ -14,11 +14,11 @@
     enable = true;
   };
   env = {
-    PALA_SUPERUSER_EMAIL = "admin@palacms.internal";
-    PALA_SUPERUSER_PASSWORD = "test1234";
-    PALA_USER_EMAIL = "user@palacms.internal";
-    PALA_USER_PASSWORD = "test1234";
-    PALA_DISABLE_USAGE_STATS = "true";
+    PRIMO_SUPERUSER_EMAIL = "admin@palacms.internal";
+    PRIMO_SUPERUSER_PASSWORD = "test1234";
+    PRIMO_USER_EMAIL = "user@palacms.internal";
+    PRIMO_USER_PASSWORD = "test1234";
+    PRIMO_DISABLE_USAGE_STATS = "true";
   };
   processes = {
     app-dev.exec = "vite --config app.config.js dev";

--- a/internal/clone.go
+++ b/internal/clone.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/types"
 )
 
-var cloneDebugEnabled = os.Getenv("PALACMS_DEBUG_CLONE") != ""
+var cloneDebugEnabled = getenvCompat("PRIMOCMS_DEBUG_CLONE", "PALACMS_DEBUG_CLONE") != ""
 
 func cloneLog(format string, args ...any) {
 	if !cloneDebugEnabled {
@@ -28,7 +28,10 @@ func cloneLog(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[clone] "+format+"\n", args...)
 }
 
-// Snapshot file signature: "PALACMS:3.0"
+// Snapshot file signature: legacy "PALACMS:3.0" magic bytes, retained so
+// existing .pala / .primo files continue to round-trip across the rebrand.
+// A new signature can be introduced when the file format changes; for now
+// we keep this as the on-disk identifier.
 var snapshotSignature = []byte{0x50, 0x41, 0x4c, 0x41, 0x43, 0x4d, 0x53, 0x3a, 0x33, 0x2e, 0x30}
 
 type SnapshotMetadata struct {

--- a/internal/devmode.go
+++ b/internal/devmode.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -68,8 +67,9 @@ const (
 )
 
 func init() {
-	// Check for dev mode via environment variable
-	if os.Getenv("PALA_DEV_MODE") == "1" {
+	// Check for dev mode via environment variable. PRIMO_DEV_MODE is the
+	// canonical name post-rebrand; PALA_DEV_MODE is accepted as a fallback.
+	if getenvCompat("PRIMO_DEV_MODE", "PALA_DEV_MODE") == "1" {
 		DevMode = true
 	}
 }
@@ -295,12 +295,12 @@ func RegisterDevMode(pb *pocketbase.PocketBase) error {
 const DevIndicatorScript = `
 <script>
 (function() {
-  const INDICATOR_ID = '__pala_dev_indicator__';
+  const INDICATOR_ID = '__primo_dev_indicator__';
   if (document.getElementById(INDICATOR_ID)) return;
 
   const style = document.createElement('style');
   style.textContent = ` + "`" + `
-    #__pala_dev_indicator__ {
+    #__primo_dev_indicator__ {
       position: relative;
       display: inline-flex;
       align-items: center;
@@ -313,26 +313,26 @@ const DevIndicatorScript = `
       border-radius: 4px;
       margin-left: 8px;
     }
-    #__pala_dev_indicator__ .dot {
+    #__primo_dev_indicator__ .dot {
       width: 8px;
       height: 8px;
       border-radius: 50%;
       transition: background 0.2s ease;
       flex-shrink: 0;
     }
-    #__pala_dev_indicator__ .dot.connected { background: #22c55e; }
-    #__pala_dev_indicator__ .dot.syncing { background: #eab308; animation: __pala_pulse 1s infinite; }
-    #__pala_dev_indicator__ .dot.pushing { background: #3b82f6; animation: __pala_pulse 0.5s infinite; }
-    #__pala_dev_indicator__ .dot.error { background: #ef4444; }
-    #__pala_dev_indicator__ .dot.disconnected { background: #6b7280; }
-    #__pala_dev_indicator__ .label {
+    #__primo_dev_indicator__ .dot.connected { background: #22c55e; }
+    #__primo_dev_indicator__ .dot.syncing { background: #eab308; animation: __primo_pulse 1s infinite; }
+    #__primo_dev_indicator__ .dot.pushing { background: #3b82f6; animation: __primo_pulse 0.5s infinite; }
+    #__primo_dev_indicator__ .dot.error { background: #ef4444; }
+    #__primo_dev_indicator__ .dot.disconnected { background: #6b7280; }
+    #__primo_dev_indicator__ .label {
       white-space: nowrap;
     }
-    @keyframes __pala_pulse {
+    @keyframes __primo_pulse {
       0%, 100% { opacity: 1; transform: scale(1); }
       50% { opacity: 0.6; transform: scale(0.9); }
     }
-    #__pala_dev_indicator__.floating {
+    #__primo_dev_indicator__.floating {
       position: fixed;
       bottom: 16px;
       right: 16px;
@@ -359,7 +359,7 @@ const DevIndicatorScript = `
     if (injected) return true;
 
     // Look for the dedicated slot first
-    const slot = document.getElementById('pala-dev-indicator-slot');
+    const slot = document.getElementById('primo-dev-indicator-slot');
     if (slot) {
       slot.appendChild(indicator);
       injected = true;

--- a/internal/env.go
+++ b/internal/env.go
@@ -1,0 +1,14 @@
+package internal
+
+import "os"
+
+// getenvCompat reads the primary env var; if it's unset, it falls back to the
+// legacy name. Used during the Pala→Primo rename so existing deployments
+// that set PALA_* keep working while new deployments can use PRIMO_*.
+// The legacy fallback is intended to be removed in a future major release.
+func getenvCompat(primary, legacy string) string {
+	if v := os.Getenv(primary); v != "" {
+		return v
+	}
+	return os.Getenv(legacy)
+}

--- a/internal/export.go
+++ b/internal/export.go
@@ -121,7 +121,7 @@ func RegisterExportEndpoint(pb *pocketbase.PocketBase) error {
 				return e.BadRequestError("Missing site ID", nil)
 			}
 
-			// Allow unauthenticated access from localhost (for pala dev)
+			// Allow unauthenticated access from localhost (for primo dev)
 			isLocal := IsLocalhost(e)
 
 			if e.Auth == nil && !isLocal {
@@ -179,7 +179,7 @@ func exportSiteToZip(pb *pocketbase.PocketBase, site *core.Record) ([]byte, erro
 	siteId := site.Id
 
 	// 1. Write site.yaml
-	palaConfig := ExportedSite{
+	siteConfig := ExportedSite{
 		Name:       site.GetString("name"),
 		Host:       site.GetString("host"),
 		SiteID:     siteId,
@@ -187,7 +187,7 @@ func exportSiteToZip(pb *pocketbase.PocketBase, site *core.Record) ([]byte, erro
 		ExportedAt: site.GetString("updated"),
 		Version:    "1.0",
 	}
-	if err := writeYAMLToZip(zw, "site.yaml", palaConfig); err != nil {
+	if err := writeYAMLToZip(zw, "site.yaml", siteConfig); err != nil {
 		return nil, err
 	}
 

--- a/internal/info.go
+++ b/internal/info.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"os"
 	"time"
 
 	"github.com/pocketbase/pocketbase"
@@ -11,7 +10,7 @@ import (
 
 // Check if running in hosted mode (managed SaaS)
 func isHostedMode() bool {
-	return os.Getenv("PALA_HOSTED_MODE") == "true"
+	return getenvCompat("PRIMO_HOSTED_MODE", "PALA_HOSTED_MODE") == "true"
 }
 
 var buildTime string
@@ -97,7 +96,7 @@ func RegisterInfoEndpoint(pb *pocketbase.PocketBase) error {
 				TelemetryEnabled: false, // Analytics disabled
 				SMTPEnabled:      smtpEnabled,
 				HostedMode:       isHostedMode(),
-				BillingURL:       os.Getenv("PALA_BILLING_URL"),
+				BillingURL:       getenvCompat("PRIMO_BILLING_URL", "PALA_BILLING_URL"),
 				DevMode:          DevMode,
 			})
 		})

--- a/internal/localhost.go
+++ b/internal/localhost.go
@@ -62,7 +62,7 @@ func RegisterDevAuthEndpoint(pb *pocketbase.PocketBase) error {
 			// a genuine miss; any other error (DB outage, misconfigured
 			// users collection, etc.) means we shouldn't proceed to create
 			// a duplicate or mask a real failure.
-			devEmail := "dev@pala.local"
+			devEmail := "dev@primo.local"
 			user, err := pb.FindAuthRecordByEmail("users", devEmail)
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return e.InternalServerError("Failed to look up dev user", err)

--- a/internal/stats.go
+++ b/internal/stats.go
@@ -1,12 +1,14 @@
 /**
- * Pala CMS Usage Statistics
+ * Primo CMS Usage Statistics
  *
- * This module collects anonymous usage statistics to help improve Pala CMS.
- * Data collection is privacy-focused and can be disabled by setting PALA_DISABLE_USAGE_STATS=true
+ * This module collects anonymous usage statistics to help improve Primo CMS.
+ * Data collection is privacy-focused and can be disabled by setting
+ * PRIMO_DISABLE_USAGE_STATS=true (PALA_DISABLE_USAGE_STATS is accepted as a
+ * fallback for existing deployments).
  *
  * What we collect:
  * - Anonymous instance ID (random UUID, not linked to any personal data)
- * - Pala CMS version number
+ * - Primo CMS version number
  * - Count of sites, pages, and users (numbers only, no content)
  * - Basic error events (sanitized, no user data)
  * - Geographic location (city-level only)
@@ -18,7 +20,7 @@
  * - Session recordings or screenshots
  * - Any personally identifiable information
  *
- * To disable: Set PALA_DISABLE_USAGE_STATS=true in your environment variables
+ * To disable: Set PRIMO_DISABLE_USAGE_STATS=true in your environment variables
  */
 
 package internal

--- a/migrations/1757326540_settings.go
+++ b/migrations/1757326540_settings.go
@@ -7,20 +7,30 @@ import (
 	m "github.com/pocketbase/pocketbase/migrations"
 )
 
+// getenvCompat is defined in internal/env.go; the migrations package can't
+// import internal, so we inline the same legacy-fallback semantics here for
+// the few env vars this migration reads.
+func envWithFallback(primary, legacy string) string {
+	if v := os.Getenv(primary); v != "" {
+		return v
+	}
+	return os.Getenv(legacy)
+}
+
 func init() {
 	m.Register(
 		func(app core.App) error {
 			settings := app.Settings()
-			appURL := os.Getenv("PALA_APP_URL")
+			appURL := envWithFallback("PRIMO_APP_URL", "PALA_APP_URL")
 			if appURL != "" {
 				settings.Meta.AppURL = appURL
 			}
 
-			settings.Meta.AppName = "Pala CMS"
+			settings.Meta.AppName = "Primo CMS"
 			app.Save(settings)
 
-			superuserEmail := os.Getenv("PALA_SUPERUSER_EMAIL")
-			superuserPassword := os.Getenv("PALA_SUPERUSER_PASSWORD")
+			superuserEmail := envWithFallback("PRIMO_SUPERUSER_EMAIL", "PALA_SUPERUSER_EMAIL")
+			superuserPassword := envWithFallback("PRIMO_SUPERUSER_PASSWORD", "PALA_SUPERUSER_PASSWORD")
 			if superuserEmail != "" && superuserPassword != "" {
 				collection, err := app.FindCollectionByNameOrId("_superusers")
 				if err != nil {
@@ -33,8 +43,8 @@ func init() {
 				app.Save(record)
 			}
 
-			userEmail := os.Getenv("PALA_USER_EMAIL")
-			userPassword := os.Getenv("PALA_USER_PASSWORD")
+			userEmail := envWithFallback("PRIMO_USER_EMAIL", "PALA_USER_EMAIL")
+			userPassword := envWithFallback("PRIMO_USER_PASSWORD", "PALA_USER_PASSWORD")
 			if userEmail != "" && userPassword != "" {
 				collection, err := app.FindCollectionByNameOrId("users")
 				if err != nil {
@@ -44,7 +54,7 @@ func init() {
 				record := core.NewRecord(collection)
 				record.Set("email", userEmail)
 				record.Set("password", userPassword)
-				record.Set("name", "Pala Admin")
+				record.Set("name", "Primo Admin")
 				record.Set("serverRole", "developer")
 				record.SetVerified(true)
 				app.Save(record)

--- a/src/lib/builder/components/Sidebar/Sidebar_Symbol.svelte
+++ b/src/lib/builder/components/Sidebar/Sidebar_Symbol.svelte
@@ -143,20 +143,18 @@
 				getInitialData: () => ({ block: symbol }),
 				onDragStart: () => {
 					if (typeof window !== 'undefined') {
-						window.dispatchEvent(
-							new CustomEvent('palaDragStart', {
-								detail: { block: symbol }
-							})
-						)
+						const detail = { block: symbol }
+						window.dispatchEvent(new CustomEvent('primoDragStart', { detail }))
+						// Backwards-compatible alias for external listeners
+						window.dispatchEvent(new CustomEvent('palaDragStart', { detail }))
 					}
 				},
 				onDrop: () => {
 					if (typeof window !== 'undefined') {
-						window.dispatchEvent(
-							new CustomEvent('palaDragEnd', {
-								detail: { block: symbol }
-							})
-						)
+						const detail = { block: symbol }
+						window.dispatchEvent(new CustomEvent('primoDragEnd', { detail }))
+						// Backwards-compatible alias for external listeners
+						window.dispatchEvent(new CustomEvent('palaDragEnd', { detail }))
 					}
 				}
 			})

--- a/src/lib/builder/views/editor/Toolbar.svelte
+++ b/src/lib/builder/views/editor/Toolbar.svelte
@@ -333,7 +333,7 @@
 			{#if !$timeline.last}
 				<ToolbarButton id="redo" title="Redo" icon="material-symbols:redo" style="border: 0; font-size: 1.5rem;" on:click={redo_change} />
 			{/if} -->
-			<div id="pala-dev-indicator-slot"></div>
+			<div id="primo-dev-indicator-slot"></div>
 			<span class="version-badge">{instance.version}</span>
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger>

--- a/src/lib/common/models/Snapshot.ts
+++ b/src/lib/common/models/Snapshot.ts
@@ -23,9 +23,9 @@ type FileEntry = {
 }
 
 /**
- * File signature for snapshot file
- *
- * PALACMS:3.0
+ * File signature for snapshot file. Kept as the legacy "PALACMS:3.0" magic
+ * bytes so existing .pala / .primo files round-trip across the rebrand. The
+ * bytes are an on-disk identifier, not a user-visible brand string.
  */
 const SIGNATURE = new Uint8Array([0x50, 0x41, 0x4c, 0x41, 0x43, 0x4d, 0x53, 0x3a, 0x33, 0x2e, 0x30])
 const FILE_COLLECTIONS = ['site_uploads']

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,7 @@ const config = {
 				ring: 'hsl(var(--ring) / <alpha-value>)',
 				background: 'hsl(var(--background) / <alpha-value>)',
 				foreground: 'hsl(var(--foreground) / <alpha-value>)',
-				pala: 'var(--pala-primary-color)',
+				primo: 'var(--primo-primary-color)',
 				primary: {
 					DEFAULT: 'hsl(var(--primary) / <alpha-value>)',
 					foreground: 'hsl(var(--primary-foreground) / <alpha-value>)'

--- a/tests/integration/editor-context.test.mjs
+++ b/tests/integration/editor-context.test.mjs
@@ -11,8 +11,8 @@ async function loadIframeHelpers() {
 	const testableSource = source
 		.replace("import { VERSION as SVELTE_VERSION } from 'svelte/compiler'", "const SVELTE_VERSION = 'test'")
 		.replace(
-			/import \{ (?:PALA|PRIMO)_BASELINE_CSS \} from '\$lib\/common\/baseline-css'/,
-			"const PALA_BASELINE_CSS = ''; const PRIMO_BASELINE_CSS = ''"
+			/import \{ PRIMO_BASELINE_CSS \} from '\$lib\/common\/baseline-css'/,
+			"const PRIMO_BASELINE_CSS = ''"
 		)
 		.replaceAll('export const ', 'const ')
 


### PR DESCRIPTION
## Summary

First pass of the Pala → Primo rebrand inside the codebase. Scoped to cosmetic and reversible changes only — wire formats, public HTTP routes, the Go module path, and real prod infrastructure (palacms.com URLs, GHCR image, Railway template) are deferred until those move externally.

## What changed

- **Env vars** — `PRIMO_*` versions take precedence; `PALA_*` accepted as fallback via new `getenvCompat` helper (`internal/env.go`). Covers: `PRIMO_DEV_MODE`, `PRIMO_HOSTED_MODE`, `PRIMO_BILLING_URL`, `PRIMO_APP_URL`, `PRIMO_SUPERUSER_EMAIL/PASSWORD`, `PRIMO_USER_EMAIL/PASSWORD`, `PRIMOCMS_DEBUG_CLONE`, `PRIMO_DISABLE_USAGE_STATS`.
- **Dev-indicator DOM IDs** — `__pala_dev_indicator__` → `__primo_dev_indicator__`, `__pala_pulse` → `__primo_pulse`, `pala-dev-indicator-slot` → `primo-dev-indicator-slot`. Slot consumer in `Toolbar.svelte` updated.
- **Custom events** — `primoDragStart` / `primoDragEnd` now dispatch alongside the legacy `palaDragStart` / `palaDragEnd` so external listeners keep working.
- **Settings migration** — `appName = "Primo CMS"`, admin name `"Primo Admin"` (fresh installs only — migration is keyed to its legacy filename and won't re-run on existing DBs).
- **Tailwind** — `pala:` color slot renamed to `primo:` (was unused).
- **Dev user email** — `dev@pala.local` → `dev@primo.local`. Existing dev DBs will create a fresh dev user on next dev-auth call; the old record is harmlessly orphaned.
- **Docs** — CONTRIBUTING.md (full pass), DEVELOPERS.md + SECURITY.md (brand prose only; palacms.com URLs and security@palacms.com left in place since the domain hasn't moved).
- **Dockerfile** — build arg `PALA_VERSION` → `PRIMO_VERSION`; matching update in `main.yml` and `tag.yml` workflows.
- **Internal cleanup** — `palaConfig` → `siteConfig` in `export.go`; stats.go header and doc comments; test regex drops the `PALA` branch (baseline-css.ts is already PRIMO-only).

## Deferred to phase 2 (need coordinated external moves first)

- Go module path `github.com/palacms/palacms` — depends on the GitHub org/repo rename
- HTTP API routes `/api/palacms/*` — public contract with primo-cli
- Snapshot file signature `PALACMS:3.0` magic bytes — on-disk format compat with existing `.pala` / `.primo` files
- Binary name `palacms` (release artifacts, build banner, Docker container name)
- `package.json` name `"palacms"`
- `palacms.com` URLs in README + docs (real domain, hasn't moved)
- `deployment/production/compose.yaml` (real prod infra: traefik routes, container names)
- PostHog event name `send_palacms_usage_stats`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/...` clean
- [x] `go test ./internal/...` for TestImport / TestLibrary / TestEditorContext / TestExport — all pass
- [x] `node tests/integration/editor-context.test.mjs` — passes
- [ ] Smoke-check dev indicator still renders in local dev (DOM IDs renamed)
- [ ] Verify `PALA_*` env vars still work for an existing deployment, with `PRIMO_*` taking precedence when both are set
- [ ] Fresh install writes `appName = "Primo CMS"` in PocketBase settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable naming across build configurations, Docker setup, and deployment settings with backward compatibility support for legacy names
  * Updated build arguments and internal identifiers

* **Documentation**
  * Refreshed contributing, security, and developer documentation with current project terminology

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/palacms/palacms/pull/1132)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->