### PR TITLE
Build frontend in release workflow so binaries actually get produced

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,21 +34,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build frontend
+        run: |
+          npm ci
+          npx svelte-kit sync
+          npx vite --config common.config.js build
+          npx vite --config app.config.js build
+        shell: bash
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25'
 
       - name: Build binary
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          PRIMO_VERSION: ${{ github.ref_name }}
         run: |
           ext=""
           if [ "${{ matrix.goos }}" = "windows" ]; then
             ext=".exe"
           fi
-          go build -ldflags="-s -w" -o palacms_${{ matrix.goos }}_${{ matrix.goarch }}${ext} .
+          go build \
+            -ldflags="-s -w \
+              -X 'github.com/palacms/palacms/internal.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)' \
+              -X 'github.com/palacms/palacms/internal.buildVersion=${PRIMO_VERSION}'" \
+            -o palacms_${{ matrix.goos }}_${{ matrix.goarch }}${ext} .
         shell: bash
 
       - name: Upload artifact
@@ -68,8 +86,8 @@ jobs:
           path: binaries
           merge-multiple: true
 
-      - name: Create release
+      - name: Upload assets to release
         uses: softprops/action-gh-release@v1
         with:
           files: binaries/*
-          generate_release_notes: true
+          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload assets to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: binaries/*
           draft: true


### PR DESCRIPTION
## Summary

- Add Node 22 + `npm ci` + the two `vite build` steps to the matrix job so `internal/admin.go`'s `//go:embed build/*` has the SvelteKit output to embed.
- Bump Go from 1.21 → 1.25 to match the Dockerfile and devenv.
- Inject `buildVersion` / `buildTime` ldflags so released binaries report their version (mirrors Dockerfile and tag.yml).
- Switch the release step to `draft: true` and drop `generate_release_notes` so an existing draft (e.g. the current v3.2.0 with hand-written notes) gets assets uploaded in place rather than published or having auto-generated notes appended.

The existing workflow has never produced working binaries — every `v*` tag push must have failed at `go build` because there's no `internal/build/` directory until the frontend has been built. This is why the v3.1.0 release has empty assets and `primo dev` (in primo-cli) currently 404s.

## Test plan
- [ ] Merge this, then push the `v3.2.0` tag.
- [ ] Workflow runs all 5 matrix jobs to completion.
- [ ] All 5 binaries appear as assets on the existing v3.2.0 draft.
- [ ] Draft remains a draft (manual publish step).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline now runs frontend setup and bundle steps before compiling backend binaries.
  * Toolchain updated to a newer Go version.
  * Produced binaries include embedded version and build timestamp metadata.
  * Release publishing now uploads assets to a draft release instead of auto-creating release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->