### PR TITLE
Preserve group name on push + drop Iterator.from from OrderedSvelteMap

### DIFF
--- a/internal/bootstrap.go
+++ b/internal/bootstrap.go
@@ -219,7 +219,12 @@ func ensureBootstrapGroups(pb *pocketbase.PocketBase, groups []bootstrapSiteGrou
 func ensureBootstrapGroup(pb *pocketbase.PocketBase, group bootstrapSiteGroup) (string, error) {
 	groupID := strings.TrimSpace(group.ID)
 	groupName := strings.TrimSpace(group.Name)
-	if groupName == "" {
+	// nameProvided distinguishes "caller passed an explicit name" from
+	// "caller only had an ID". On the push path the CLI only knows the group
+	// ID, so we must NOT synthesize a name from the ID and then overwrite a
+	// user's existing label (e.g. clobbering "Clients" with "8Y17hao5jt2xmd8").
+	nameProvided := groupName != ""
+	if !nameProvided {
 		groupName = humanizeGroupID(groupID)
 	}
 	if groupName == "" {
@@ -239,8 +244,12 @@ func ensureBootstrapGroup(pb *pocketbase.PocketBase, group bootstrapSiteGroup) (
 	}
 
 	if existingGroup != nil {
-		existingGroup.Set("name", groupName)
-		existingGroup.Set("index", group.Index)
+		if nameProvided {
+			existingGroup.Set("name", groupName)
+		}
+		if group.Index != 0 {
+			existingGroup.Set("index", group.Index)
+		}
 		if err := pb.Save(existingGroup); err != nil {
 			return "", err
 		}

--- a/internal/import.go
+++ b/internal/import.go
@@ -232,6 +232,10 @@ func handleImport(pb *pocketbase.PocketBase, e *core.RequestEvent, previewOnly b
 	// dashboard or by bootstrap), and a file→CMS push must never overwrite
 	// the routing host out from under the user.
 	siteName, siteGroup := readSiteConfigFromZip(zipData)
+	// site.yaml only stores the group ID. The CLI sends the group's display
+	// name out-of-band (from workspace server.yaml) so first-time pushes of
+	// a new group land with the right label instead of a humanized ID.
+	siteGroupName := strings.TrimSpace(e.Request.FormValue("group_name"))
 
 	// Find the site or create it if it doesn't exist
 	siteCreated := false
@@ -252,7 +256,7 @@ func handleImport(pb *pocketbase.PocketBase, e *core.RequestEvent, previewOnly b
 			return e.InternalServerError("Failed to ensure default site group", groupErr)
 		}
 		if siteGroup != "" {
-			if resolvedGroupId, resolveErr := ensureBootstrapGroup(pb, bootstrapSiteGroup{ID: siteGroup}); resolveErr == nil {
+			if resolvedGroupId, resolveErr := ensureBootstrapGroup(pb, bootstrapSiteGroup{ID: siteGroup, Name: siteGroupName}); resolveErr == nil {
 				groupId = resolvedGroupId
 			}
 		}
@@ -299,7 +303,7 @@ func handleImport(pb *pocketbase.PocketBase, e *core.RequestEvent, previewOnly b
 			dirty = true
 		}
 		if siteGroup != "" {
-			resolvedGroupId, resolveErr := ensureBootstrapGroup(pb, bootstrapSiteGroup{ID: siteGroup})
+			resolvedGroupId, resolveErr := ensureBootstrapGroup(pb, bootstrapSiteGroup{ID: siteGroup, Name: siteGroupName})
 			if resolveErr == nil && site.GetString("group") != resolvedGroupId {
 				site.Set("group", resolvedGroupId)
 				dirty = true

--- a/src/lib/pocketbase/OrderedSvelteMap.ts
+++ b/src/lib/pocketbase/OrderedSvelteMap.ts
@@ -7,20 +7,17 @@ import { SvelteMap } from 'svelte/reactivity'
 export class OrderedSvelteMap<K, V> extends SvelteMap<K, V> {
 	private order: K[] = []
 
-	private iterator() {
-		const map = this
-		return Iterator.from({
-			*[Symbol.iterator]() {
-				for (const key of map.order) {
-					const value = map.get(key)
-					yield [key, value] as [K, V]
-				}
-			}
-		})
+	private *iterator(): IterableIterator<[K, V]> {
+		for (const key of this.order) {
+			const value = super.get(key) as V
+			yield [key, value]
+		}
 	}
 
 	forEach(callbackfn: (value: V, key: K, thisArg?: any) => void): void {
-		this.entries().forEach(([key, value]) => callbackfn(value, key, this))
+		for (const [key, value] of this.iterator()) {
+			callbackfn(value, key, this)
+		}
 	}
 
 	set(key: K, value: V): this {
@@ -42,17 +39,17 @@ export class OrderedSvelteMap<K, V> extends SvelteMap<K, V> {
 		super.clear()
 	}
 
-	keys() {
+	*keys(): IterableIterator<K> {
 		super.keys()
-		return this.iterator().map(([key]) => key)
+		for (const [key] of this.iterator()) yield key
 	}
 
-	values() {
+	*values(): IterableIterator<V> {
 		super.values()
-		return this.iterator().map(([, value]) => value)
+		for (const [, value] of this.iterator()) yield value
 	}
 
-	entries() {
+	entries(): IterableIterator<[K, V]> {
 		super.entries()
 		return this.iterator()
 	}


### PR DESCRIPTION
## Summary

- **Group name on push** — `site.yaml` only stores the group ID, so on a file→CMS push the server previously synthesized a name from the ID (`humanizeGroupID`) and overwrote whatever the user had set in the dashboard (e.g. clobbering "Clients" with "8Y17hao5jt2xmd8"). The CLI already sends the group's display name out-of-band as `group_name`; `import.go` now reads it and threads it into `ensureBootstrapGroup`. `bootstrap.go` only overwrites the existing group's `name` / `index` when those were explicitly provided.
- **OrderedSvelteMap** — replace TC39 `Iterator.from(...)` with plain generators (`*keys`, `*values`, etc.) for runtime compatibility; use `super.get` inside the iterator to bypass reactive tracking during iteration.

## Test plan
- [ ] Push a site whose group has been renamed in the dashboard — group name stays put after the push.
- [ ] Push a site to a brand-new group — group lands with the CLI-supplied label, not a humanized ID.
- [ ] `OrderedSvelteMap` iteration (`for…of`, `forEach`, `.keys()` etc.) still works on a runtime without Iterator Helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site group names are now correctly preserved during bootstrap operations.

* **Improvements**
  * Group display names are now properly resolved and maintained during site creation and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->