### PR TITLE
Extend users password reset token TTL to 30 days

### DIFF
--- a/migrations/1757326533_collections_snapshot.go
+++ b/migrations/1757326533_collections_snapshot.go
@@ -773,7 +773,7 @@ func init() {
 					]
 				},
 				"passwordResetToken": {
-					"duration": 1800
+					"duration": 2592000
 				},
 				"resetPasswordTemplate": {
 					"body": "<p>Hello,</p>\n<p>Click on the button below to reset your password.</p>\n<p>\n  <a class=\"btn\" href=\"{APP_URL}/admin/auth?reset={TOKEN}\" target=\"_blank\" rel=\"noopener\">Reset password</a>\n</p>\n<p><i>If you didn't ask to reset your password, you can ignore this email.</i></p>\n<p>\n  Thanks,<br/>\n  {APP_NAME} team\n</p>",


### PR DESCRIPTION
addresses issue where collaborator invitations don't work

## Summary
- Bumps `users.passwordResetToken.duration` in the collections snapshot from 1800s (30 min) to 2592000s (30 days).
- Collaboration invite links (`/admin/auth?create=<token>&email=…`) reuse PocketBase's password reset token. With a 30-minute TTL, invitees who didn't click immediately hit an expired-token error with no clear recovery path — surfaced as "I can't create my account."

## Scope
- Snapshot-only change: only applies to fresh installs. Existing instances keep `1800` and need to update via PocketBase admin (Collections → users → Options → Password reset duration).
- `_superusers` token TTL is intentionally left at 1800 — admin password resets should stay short-lived.

## Test plan
- [ ] Fresh install picks up `2592000` on the users collection
- [ ] Generate a collaboration link, wait >30 min, confirm it still works
- [ ] Existing installs unaffected until manually bumped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated password reset token configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->