### PR TITLE
Fix image-upload leakage across shared records + finish pala→primo rename

### DIFF
--- a/internal/clone.go
+++ b/internal/clone.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/types"
 )
 
-var cloneDebugEnabled = os.Getenv("PRIMOCMS_DEBUG_CLONE") != ""
+var cloneDebugEnabled = os.Getenv("PRIMO_DEBUG_CLONE") != ""
 
 func cloneLog(format string, args ...any) {
 	if !cloneDebugEnabled {

--- a/internal/devmode.go
+++ b/internal/devmode.go
@@ -236,7 +236,7 @@ func RegisterDevMode(pb *pocketbase.PocketBase) error {
 		})
 
 		// WebSocket endpoint for dev indicator
-		serveEvent.Router.GET("/__pala_dev_ws__", func(e *core.RequestEvent) error {
+		serveEvent.Router.GET("/__primo_dev_ws__", func(e *core.RequestEvent) error {
 			if !IsLocalhost(e) {
 				return e.ForbiddenError("Localhost only", nil)
 			}
@@ -409,7 +409,7 @@ const DevIndicatorScript = `
 
   function connect() {
     const wsScheme = location.protocol === 'https:' ? 'wss://' : 'ws://';
-    const wsUrl = wsScheme + location.host + '/__pala_dev_ws__';
+    const wsUrl = wsScheme + location.host + '/__primo_dev_ws__';
     ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {

--- a/internal/stats.go
+++ b/internal/stats.go
@@ -143,7 +143,7 @@ func RegisterUsageStats(pb *pocketbase.PocketBase) error {
 
 		// Set up daily heartbeat
 		if err := pb.Cron().Add(
-			"send_palacms_usage_stats",
+			"send_primo_usage_stats",
 			"@daily",
 			func() { sendUsageStats(pb) },
 		); err != nil {

--- a/src/lib/Content.svelte.ts
+++ b/src/lib/Content.svelte.ts
@@ -343,7 +343,11 @@ export const useContent = <Collection extends keyof typeof ENTITY_COLLECTIONS>(e
 				}
 				if (!content[entry.locale]) content[entry.locale] = {}
 
-				const normalized_value = normalize_entry_value(entry.value) as Record<string, unknown>
+				const normalized_value = normalize_entry_value(entry.value) as Record<string, unknown> | null
+				if (!normalized_value) {
+					content[entry.locale]![field.key] = get_empty_value(field)
+					continue
+				}
 				const upload_id: string | null | undefined = normalized_value.upload as string | null | undefined
 				const upload = upload_id ? uploads.find((upload) => upload.id === upload_id) : null
 

--- a/src/lib/Content.svelte.ts
+++ b/src/lib/Content.svelte.ts
@@ -365,7 +365,6 @@ export const useContent = <Collection extends keyof typeof ENTITY_COLLECTIONS>(e
 				const width: number | null | undefined = normalized_value.width as number | null | undefined
 				const height: number | null | undefined = normalized_value.height as number | null | undefined
 				content[entry.locale]![field.key] = { alt, url, width, height }
-				content[entry.locale]![field.key] = { alt, url }
 			}
 
 			// Handle page fields specially - get content from the page entity

--- a/src/lib/builder/field-types/ImageField.svelte
+++ b/src/lib/builder/field-types/ImageField.svelte
@@ -95,12 +95,12 @@
 			// Extract dimensions from the compressed/final image
 			const dimensions = await get_image_dimensions(file_to_upload)
 
+			// Always create a new upload record instead of updating the existing one in place.
+			// Upload records can be shared by multiple entries (copied sections, duplicated
+			// repeater items, cloned sites), so an in-place update would change the image
+			// everywhere the record is referenced.
 			let upload_record
-			if (upload && site) {
-				upload_record = SiteUploads.update(upload.id, { file: file_to_upload })
-			} else if (upload) {
-				upload_record = LibraryUploads.update(upload.id, { file: file_to_upload })
-			} else if (site) {
+			if (site) {
 				upload_record = SiteUploads.create({ file: file_to_upload, site: site.id })
 			} else {
 				upload_record = LibraryUploads.create({ file: file_to_upload })
@@ -129,7 +129,10 @@
 
 	let width = $state<number | undefined>()
 	let collapsed = $derived(!width || width < 200)
-	let upload = $derived(entry.value.upload ? ('site' in field && site ? SiteUploads.one(entry.value.upload) : LibraryUploads.one(entry.value.upload)) : null)
+	// Uploads belong to the site when editing within a site context (symbol and page-type
+	// fields have no `site` property, so checking the field would wrongly resolve site
+	// uploads through LibraryUploads).
+	let upload = $derived(entry.value.upload ? (site ? SiteUploads.one(entry.value.upload) : LibraryUploads.one(entry.value.upload)) : null)
 	let upload_url = $derived(
 		upload && (typeof upload.file === 'string' ? `${self.instance?.baseURL}/api/files/${site ? 'site_uploads' : 'library_uploads'}/${upload.id}/${upload.file}` : URL.createObjectURL(upload.file))
 	)


### PR DESCRIPTION
## Image-upload fixes (`15b98c8d`)
- **Stop in-place upload updates.** `ImageField` updated upload records in place, but a record can be referenced by multiple entries (copied sections, cloned sites, duplicated repeater items) — editing one image changed it everywhere. Now always creates a new upload record.
- **Resolve uploads by `site` presence** rather than `'site' in field`, so symbol/page-type fields (no `site` prop) don't wrongly look up site uploads in the library.
- **Null-guard `normalize_entry_value`** in `useContent` — falls back to the field's empty value instead of dereferencing null.

## Rename cleanup (`404805c3`)
Leftover `pala`/`palacms` identifiers missed in phase 2:
- debug env var `PRIMOCMS_DEBUG_CLONE` → `PRIMO_DEBUG_CLONE`
- dev-mode WS endpoint `/__pala_dev_ws__` → `/__primo_dev_ws__` (server route + inline client script; verified no other consumers)
- usage-stats cron id `send_palacms_usage_stats` → `send_primo_usage_stats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image field handling so missing or unnormalized image values won’t break content loading, and resolved image data now includes width/height.
  * Image uploads now create a new upload record more consistently, reducing stale upload state.
  * Updated the dev-mode WebSocket connection path so dev indicators connect correctly.
* **Chores**
  * Renamed internal debug and usage-tracking identifiers for consistency (including switching clone debug to the new environment variable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->