### PR TITLE
Round-trip page-type body sections through layout.yaml

### DIFF
--- a/internal/export.go
+++ b/internal/export.go
@@ -61,22 +61,29 @@ type ExportedPageType struct {
 // as block fields.yaml and site/fields.yaml.
 type ExportedPageTypeFields []interface{}
 
-// ExportedLayout represents a page type's layout (header/footer sections)
+// ExportedLayout represents a page type's layout (header/body/footer sections).
+// Body sections are seed defaults for newly created pages of this type — they are
+// copied onto a page's own sections at creation, not rendered from the layout.
 type ExportedLayout struct {
 	Header        []ExportedLayoutSection `yaml:"header,omitempty"`
+	Body          []ExportedLayoutSection `yaml:"body,omitempty"`
 	Footer        []ExportedLayoutSection `yaml:"footer,omitempty"`
 	AllowedBlocks []string                `yaml:"allowed_blocks,omitempty"`
 }
 
 // emptyLayoutTemplate is what we write to page-types/<key>/layout.yaml when
-// the page type has no header/footer sections defined. The whole thing is
+// the page type has no header/body/footer sections defined. The whole thing is
 // commented so it doubles as inline documentation showing what's possible
 // without becoming live config.
 const emptyLayoutTemplate = `# Sections shared by every page of this type. Add blocks here to render
-# the same header/footer across all pages of this type.
+# the same header/footer across all pages of this type. Body sections are
+# seeded onto each newly created page of this type (and locked when the type
+# has no allowed_blocks).
 #
 # header:
 #   - block: site-header
+# body:
+#   - block: hero
 # footer:
 #   - block: site-footer
 `
@@ -452,13 +459,14 @@ func exportSiteToZip(pb *pocketbase.PocketBase, site *core.Record) ([]byte, erro
 			}
 		}
 
-		// Fetch header/footer slots (page_type_sections) with their content
+		// Fetch header/body/footer slots (page_type_sections) with their content
 		ptSections, err := pb.FindRecordsByFilter("page_type_sections", "page_type = {:pt}", "+index", 0, 0, dbx.Params{"pt": pt.Id})
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch page type sections: %w", err)
 		}
 
 		headerSections := make([]map[string]interface{}, 0)
+		bodySections := make([]map[string]interface{}, 0)
 		footerSections := make([]map[string]interface{}, 0)
 		for _, section := range ptSections {
 			slot := section.GetString("zone")
@@ -503,20 +511,25 @@ func exportSiteToZip(pb *pocketbase.PocketBase, site *core.Record) ([]byte, erro
 
 			if slot == "header" {
 				headerSections = append(headerSections, sectionData)
+			} else if slot == "body" {
+				bodySections = append(bodySections, sectionData)
 			} else if slot == "footer" {
 				footerSections = append(footerSections, sectionData)
 			}
 		}
 
-		// layout.yaml is always emitted. When the page type has header/footer
+		// layout.yaml is always emitted. When the page type has header/body/footer
 		// sections, we write them; otherwise we write the comment-only
 		// template so the file's purpose is self-documenting and importers /
 		// validators can rely on its presence.
 		layoutPath := fmt.Sprintf("page-types/%s/layout.yaml", ptName)
-		if len(headerSections) > 0 || len(footerSections) > 0 {
+		if len(headerSections) > 0 || len(bodySections) > 0 || len(footerSections) > 0 {
 			layout := map[string]interface{}{}
 			if len(headerSections) > 0 {
 				layout["header"] = headerSections
+			}
+			if len(bodySections) > 0 {
+				layout["body"] = bodySections
 			}
 			if len(footerSections) > 0 {
 				layout["footer"] = footerSections

--- a/internal/import.go
+++ b/internal/import.go
@@ -2921,6 +2921,50 @@ func importPageType(pb *pocketbase.PocketBase, site *core.Record, ptFolder strin
 			}
 		}
 
+		// Import body sections into the page type layout (zone "body"). These are
+		// seed defaults only: the editor copies them onto a page's own sections
+		// when a new page of this type is created. Import writes the page-type
+		// layout exclusively — it never creates or mutates pages, and the renderer
+		// sources page body from each page's own sections, not from here. A body
+		// block may reference a block outside allowed_blocks — that is allowed by
+		// design (e.g. a one-off hero), so we only warn when the block is not a
+		// registered symbol at all.
+		for i, sectionData := range layoutData.Body {
+			symbolId := symbolByName[sectionData.Block]
+			if symbolId == "" {
+				symbolId = symbolByName[strings.ToLower(sectionData.Block)]
+			}
+			if symbolId == "" {
+				*warnings = append(*warnings, ImportWarning{
+					Kind:    "missing_symbol",
+					File:    layoutPath,
+					Path:    fmt.Sprintf("body[%d].block", i),
+					Block:   sectionData.Block,
+					Message: fmt.Sprintf("body[%d] references block %q, which is not a registered symbol on this site. New pages of this type will seed with no block for this section. Add blocks/%s/ or fix the reference.", i, sectionData.Block, sectionData.Block),
+				})
+				continue
+			}
+
+			section := core.NewRecord(ptSectionsColl)
+			section.Set("page_type", pageType.Id)
+			section.Set("zone", "body")
+			section.Set("index", i)
+			section.Set("symbol", symbolId)
+
+			if err := pb.Save(section); err != nil {
+				return err
+			}
+
+			// Import content entries for this section. If layout.yaml omits
+			// content, seed it from the block's content.yaml defaults so
+			// layout-mounted blocks behave like newly-added page sections.
+			if content := resolveLayoutContent(sectionData); content != nil {
+				if err := importPageTypeSectionContent(pb, section, symbolFields[symbolId], content); err != nil {
+					return err
+				}
+			}
+		}
+
 		// Import footer sections
 		for i, sectionData := range layoutData.Footer {
 			symbolId := symbolByName[sectionData.Block]

--- a/internal/import_test.go
+++ b/internal/import_test.go
@@ -1002,3 +1002,155 @@ func readZipFileBytes(t *testing.T, zipData []byte, name string) []byte {
 	t.Fatalf("missing zip entry %s", name)
 	return nil
 }
+
+// TestImportLayoutBodySectionsRoundTrip verifies that layout.yaml header/body/footer
+// sections import into page_type_sections with the right zones, that a body block
+// outside allowed_blocks is accepted without warning (seed-only, by design), and
+// that the layout round-trips back out through export with body preserved.
+func TestImportLayoutBodySectionsRoundTrip(t *testing.T) {
+	app := newImportTestApp(t)
+	defer app.ResetBootstrapState()
+
+	site := createImportTestSite(t, app)
+
+	files := map[string]string{
+		"blocks/site-header/config.yaml":      "name: site-header\n",
+		"blocks/site-header/component.svelte": "<header>hi</header>\n",
+		"blocks/site-header/fields.yaml":      "[]\n",
+		"blocks/site-header/content.yaml":     "{}\n",
+		"blocks/site-footer/config.yaml":      "name: site-footer\n",
+		"blocks/site-footer/component.svelte": "<footer>bye</footer>\n",
+		"blocks/site-footer/fields.yaml":      "[]\n",
+		"blocks/site-footer/content.yaml":     "{}\n",
+		// hero carries a field so we can assert body content survives the round-trip
+		"blocks/hero/config.yaml":      "name: hero\n",
+		"blocks/hero/component.svelte": "<section>{heading}</section>\n",
+		"blocks/hero/fields.yaml": "" +
+			"- name: heading\n" +
+			"  label: Heading\n" +
+			"  type: text\n",
+		"blocks/hero/content.yaml": "{}\n",
+		// cta is intentionally NOT in allowed_blocks — a one-off body seed block.
+		"blocks/cta/config.yaml":      "name: cta\n",
+		"blocks/cta/component.svelte": "<div>cta</div>\n",
+		"blocks/cta/fields.yaml":      "[]\n",
+		"blocks/cta/content.yaml":     "{}\n",
+		// allowed_blocks lists only hero (dynamic type); cta is omitted on purpose.
+		"page-types/default/config.yaml": "name: Default\nallowed_blocks:\n  - hero\n",
+		"page-types/default/fields.yaml": "[]\n",
+		"page-types/default/layout.yaml": "" +
+			"header:\n" +
+			"  - block: site-header\n" +
+			"body:\n" +
+			"  - block: hero\n" +
+			"    content:\n" +
+			"      heading: Welcome\n" +
+			"  - block: cta\n" +
+			"footer:\n" +
+			"  - block: site-footer\n",
+		"pages/index.yaml":  "name: Home\npage_type: Default\nsections: []\n",
+		"site/fields.yaml":  "[]\n",
+		"site/content.yaml": "{}\n",
+	}
+
+	result, err := processImport(app, site, zipFiles(t, files), false)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	// cta is outside allowed_blocks but IS a registered symbol, so no warning.
+	if len(result.Warnings) > 0 {
+		t.Fatalf("expected no import warnings, got %#v", result.Warnings)
+	}
+
+	// Resolve the page type, then assert the imported section zones.
+	pageTypes, err := app.FindRecordsByFilter("page_types", "site = {:site}", "", 0, 0, map[string]any{"site": site.Id})
+	if err != nil || len(pageTypes) != 1 {
+		t.Fatalf("fetch page type: %v (%d found)", err, len(pageTypes))
+	}
+	sections, err := app.FindRecordsByFilter("page_type_sections", "page_type = {:pt}", "+zone,+index", 0, 0, map[string]any{"pt": pageTypes[0].Id})
+	if err != nil {
+		t.Fatalf("fetch page type sections: %v", err)
+	}
+	zoneCounts := map[string]int{}
+	for _, s := range sections {
+		zoneCounts[s.GetString("zone")]++
+	}
+	if zoneCounts["header"] != 1 || zoneCounts["body"] != 2 || zoneCounts["footer"] != 1 {
+		t.Fatalf("unexpected zone counts: %#v", zoneCounts)
+	}
+
+	// Round-trip: export and confirm body survives with its content.
+	exportedZip, err := exportSiteToZip(app, site)
+	if err != nil {
+		t.Fatalf("export site: %v", err)
+	}
+	layoutYAML := readZipFile(t, exportedZip, "page-types/default/layout.yaml")
+	var layout struct {
+		Header []struct {
+			Block string `yaml:"block"`
+		} `yaml:"header"`
+		Body []struct {
+			Block   string         `yaml:"block"`
+			Content map[string]any `yaml:"content"`
+		} `yaml:"body"`
+		Footer []struct {
+			Block string `yaml:"block"`
+		} `yaml:"footer"`
+	}
+	if err := yaml.Unmarshal([]byte(layoutYAML), &layout); err != nil {
+		t.Fatalf("parse exported layout: %v\n%s", err, layoutYAML)
+	}
+	if len(layout.Header) != 1 || len(layout.Body) != 2 || len(layout.Footer) != 1 {
+		t.Fatalf("unexpected exported layout shape: %#v\n%s", layout, layoutYAML)
+	}
+	if layout.Body[0].Block != "hero" || layout.Body[1].Block != "cta" {
+		t.Fatalf("body section order/blocks wrong: %#v\n%s", layout.Body, layoutYAML)
+	}
+	if got := layout.Body[0].Content["heading"]; got != "Welcome" {
+		t.Fatalf("body content did not survive round-trip, got %#v\n%s", got, layoutYAML)
+	}
+
+	// Importing body must not have created any pages or page sections.
+	pageSections, err := app.FindRecordsByFilter("page_sections", "page.site = {:site}", "", 0, 0, map[string]any{"site": site.Id})
+	if err != nil {
+		t.Fatalf("fetch page sections: %v", err)
+	}
+	if len(pageSections) != 0 {
+		t.Fatalf("import seeded page sections from layout body, expected none, got %d", len(pageSections))
+	}
+}
+
+// TestImportLayoutBodyMissingSymbolWarns verifies that a body block referencing an
+// unregistered symbol (no blocks/<name>/) produces a missing_symbol warning, unlike
+// the allowed_blocks case which is silent.
+func TestImportLayoutBodyMissingSymbolWarns(t *testing.T) {
+	app := newImportTestApp(t)
+	defer app.ResetBootstrapState()
+
+	site := createImportTestSite(t, app)
+
+	files := map[string]string{
+		"page-types/default/config.yaml": "name: Default\n",
+		"page-types/default/fields.yaml": "[]\n",
+		"page-types/default/layout.yaml": "" +
+			"body:\n" +
+			"  - block: ghost\n",
+		"pages/index.yaml":  "name: Home\npage_type: Default\nsections: []\n",
+		"site/fields.yaml":  "[]\n",
+		"site/content.yaml": "{}\n",
+	}
+
+	result, err := processImport(app, site, zipFiles(t, files), false)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	found := false
+	for _, w := range result.Warnings {
+		if w.Kind == "missing_symbol" && strings.HasPrefix(w.Path, "body[") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a missing_symbol warning for body block, got %#v", result.Warnings)
+	}
+}


### PR DESCRIPTION
## Problem

A page type's body sections (`page_type_sections` with `zone = "body"`) are real, editor-authored data — the page-type layout editor lets a dev place sections in the body zone as **default sections** for new pages (dynamic types) or **fixed sections** (static types). But the file pipeline only round-tripped `header` and `footer`: body-zone sections were silently dropped on export and could not be expressed in `layout.yaml` on import.

## Change

`layout.yaml` now supports a `body:` key alongside `header:`/`footer:`.

- **export.go** — `ExportedLayout.Body`, body partition in the zone loop, body in emission + the non-empty guard, stub/comment updates.
- **import.go** — body import loop writing `zone: "body"` page-type sections.

## Semantics (decided)

- **Seed-only, never retroactive.** Import writes the page-type layout only — it never creates or mutates pages. The editor copies body sections onto a page at creation; the renderer sources page body from the page's own sections, not from `layout.yaml`. Editing `body:` after pages exist only affects pages created afterward.
- **Static vs dynamic is driven by `allowed_blocks`** (= `page_type_symbols`), not a new flag. Empty ⇒ static/locked; non-empty ⇒ dynamic defaults.
- **A body block outside `allowed_blocks` is allowed, no warning** — common one-off pattern (e.g. a homepage hero enabled, placed, then toggled off). Only a genuinely unregistered symbol warns.

## Tests

- `TestImportLayoutBodySectionsRoundTrip` — imports header/body/footer, asserts zone counts, round-trips through export (body order + content survive), and asserts **no** page sections were seeded.
- `TestImportLayoutBodyMissingSymbolWarns` — unregistered body block produces a `missing_symbol` warning.

Full `internal` suite green except a pre-existing failure (`TestUpdatedTimestampStableOnNoOpReimport`) confirmed red on baseline, unrelated to this change.

## Companion PRs

- primo-cli — `body?` type + scaffold/validation (body parsed, intentionally not rendered)
- mcp — scaffold stub + reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout import/export now supports a new middle content area alongside the existing top and bottom sections.
  * Layout files can now preserve content ordering within this new area during round-trips.

* **Bug Fixes**
  * Missing referenced blocks in the new area now produce a clear warning instead of failing silently.
  * Exported layouts now include the new area whenever it contains content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->