### PR TITLE
Skip user activity tracking in local dev

### DIFF
--- a/src/lib/UserActivity.svelte.ts
+++ b/src/lib/UserActivity.svelte.ts
@@ -8,6 +8,7 @@ import { build_cms_page_url } from './pages'
 import { site_context } from './builder/stores/context'
 import { get } from 'svelte/store'
 import { current_user } from './pocketbase/user'
+import { instance } from './instance'
 import type { ObjectOf } from './pocketbase/CollectionMapping.svelte'
 
 export type UserActivityValues = Omit<UserActivity, 'id'>
@@ -29,6 +30,11 @@ export type UserActivityInfo = {
 const user_activity_context = new Context<{ value: UserActivityValues }>('user_activity')
 
 export const setUserActivity = (overrides: Partial<UserActivityValues>) => {
+	// User activity is collaborator presence ("who else is editing this site").
+	// It's meaningless in local dev (single user, no collaborators) and would
+	// write churn records against the local DB, so don't track it there.
+	if (instance.dev_mode) return
+
 	const existing_context = user_activity_context.getOr({ value: null })
 	if (existing_context.value) {
 		// Set activity overrides through context
@@ -138,7 +144,11 @@ export const setUserActivity = (overrides: Partial<UserActivityValues>) => {
 	onDestroy(stopTracking)
 }
 
-export const getUserActivity = ({ filter }: { filter?: (activity: UserActivityInfo) => unknown } = {}) => {
+export const getUserActivity = ({ filter }: { filter?: (activity: UserActivityInfo) => unknown } = {}): UserActivityInfo[][] => {
+	// No collaborator presence in local dev — skip the list (which would also
+	// try to resolve activities pointing at since-deleted pages and throw).
+	if (instance.dev_mode) return []
+
 	const { value: site } = site_context.get()
 	return (UserActivities.list({ filter: { site: site.id } }) ?? [])
 		.filter((activity) => activity.user !== get(current_user)?.id)


### PR DESCRIPTION
## Problem

Opening the editor in local dev (`primo dev`) floods the console with repeating errors:

```
GET /api/collections/pages/records/<id> 404 (Not Found)
Invalid user_activities record {...} ZodError: path: ["id"], expected string
```

`user_activities` is a **collaborator-presence** feature — it tracks "who else is editing this site" and `getUserActivity` explicitly filters out your own activity to show only *other* users. In local dev there are no other users, so it has nothing to show. Worse, listing it resolves activity rows whose `page` points at since-deleted pages → a 404 per stale row → the related-record resolver gets a null `id` → ZodError, looping over the list.

This was previously masked by an unrelated render crash (fixed in #1179 / v3.2.1); with that gone, the editor proceeds far enough to surface this noise.

## Fix

Gate both ends on the existing `instance.dev_mode` flag (same signal already used by `Deploy.svelte`):

- `setUserActivity` returns early in dev — don't write presence churn to the local DB.
- `getUserActivity` returns `[]` in dev — don't list/resolve activities (the part that throws).

This is a design fix, not a defensive patch: the feature simply shouldn't run in single-user local dev.

## Verification

Built a local server binary embedding this change and ran it via `PRIMO_BINARY` against a real local workspace:
- **Before:** ~30+ console errors, dozens of repeating `user_activities` ZodErrors.
- **After:** the `user_activities` flood is gone; editor renders and works normally.

(One unrelated benign 404 for a single deleted-page reference remains — a separate dangling-reference issue, out of scope here.)

Production build (`vite build`) passes. The only svelte-check findings in the file are pre-existing `Timeout`-vs-`number` type nits unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local/development behavior by disabling collaborator activity tracking and activity lists in single-user development mode.
  * Prevented unnecessary background updates in dev, reducing noise and avoiding errors from stale activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->