### PR TITLE
Fix repeater subfield ordering; trim snapshot upload bloat

### DIFF
--- a/internal/export.go
+++ b/internal/export.go
@@ -1265,8 +1265,9 @@ func buildSectionContent(
 			// Repeater: each entry represents an item, children are nested under each entry.
 			// Sort items by index so exported order matches the editor — entries reach us in
 			// DB/insertion order, which diverges from index after reorders or re-imports.
+			// Stable so equal/duplicate indexes stay deterministic (no diff churn).
 			items := make([]interface{}, 0, len(fieldEntries))
-			sort.Slice(fieldEntries, func(i, j int) bool {
+			sort.SliceStable(fieldEntries, func(i, j int) bool {
 				return fieldEntries[i].GetInt("index") < fieldEntries[j].GetInt("index")
 			})
 			for _, entry := range fieldEntries {
@@ -1306,7 +1307,8 @@ func buildSectionContent(
 			} else if len(fieldEntries) > 1 {
 				// Multiple entries for same simple field (list type) — sort by index so
 				// exported order matches the editor rather than DB/insertion order.
-				sort.Slice(fieldEntries, func(i, j int) bool {
+				// Stable so equal/duplicate indexes stay deterministic (no diff churn).
+				sort.SliceStable(fieldEntries, func(i, j int) bool {
 					return fieldEntries[i].GetInt("index") < fieldEntries[j].GetInt("index")
 				})
 				vals := make([]interface{}, 0, len(fieldEntries))

--- a/internal/export.go
+++ b/internal/export.go
@@ -1262,8 +1262,13 @@ func buildSectionContent(
 
 		switch fieldType {
 		case "repeater":
-			// Repeater: each entry represents an item, children are nested under each entry
+			// Repeater: each entry represents an item, children are nested under each entry.
+			// Sort items by index so exported order matches the editor — entries reach us in
+			// DB/insertion order, which diverges from index after reorders or re-imports.
 			items := make([]interface{}, 0, len(fieldEntries))
+			sort.Slice(fieldEntries, func(i, j int) bool {
+				return fieldEntries[i].GetInt("index") < fieldEntries[j].GetInt("index")
+			})
 			for _, entry := range fieldEntries {
 				// Get children of this entry (not field)
 				childEntries := entriesByParent[entry.Id]
@@ -1299,7 +1304,11 @@ func buildSectionContent(
 			if len(fieldEntries) == 1 {
 				addKV(fieldKey, normalizeValue(fieldEntries[0].Get("value")))
 			} else if len(fieldEntries) > 1 {
-				// Multiple entries for same simple field (list type)
+				// Multiple entries for same simple field (list type) — sort by index so
+				// exported order matches the editor rather than DB/insertion order.
+				sort.Slice(fieldEntries, func(i, j int) bool {
+					return fieldEntries[i].GetInt("index") < fieldEntries[j].GetInt("index")
+				})
 				vals := make([]interface{}, 0, len(fieldEntries))
 				for _, entry := range fieldEntries {
 					vals = append(vals, normalizeValue(entry.Get("value")))

--- a/internal/import.go
+++ b/internal/import.go
@@ -1724,6 +1724,16 @@ func importPageSectionContentField(pb *pocketbase.PocketBase, entriesColl *core.
 
 	default:
 		// Simple field (text, image, link, select, etc.)
+		// A declared subfield can be absent from the YAML (e.g. a repeater item
+		// that omits an optional image). Skip it entirely rather than persisting
+		// an entry with a NULL value: the read path (useContent / get_empty_value)
+		// and the editor field components already treat a missing entry as the
+		// field's empty value, so a stored NULL only creates a landmine — e.g.
+		// ImageField dereferencing value.width on null. Skipping also keeps the
+		// YAML round-trip clean (no empty objects re-emitted on export).
+		if value == nil {
+			return nil
+		}
 		entry := core.NewRecord(entriesColl)
 		entry.Set("section", sectionId)
 		entry.Set("field", fieldId)

--- a/src/lib/Content.svelte.ts
+++ b/src/lib/Content.svelte.ts
@@ -112,6 +112,11 @@ export const useContent = <Collection extends keyof typeof ENTITY_COLLECTIONS>(e
 			.filter((field1, index, array) => array.findIndex((field2) => field2.id === field1.id) === index)
 			// Remove fields without a key
 			.filter((field) => !!field.key)
+			// Order by index so content (incl. repeater subfields) matches the editor's field order.
+			// The fields() accessor returns records in insertion (rowid) order, not index order, so
+			// without this the page renders subfields in creation order while form view (which sorts
+			// by index) looks correct — the two diverge after a reorder or a CLI re-import upsert.
+			.sort((a, b) => a.index - b.index)
 
 		for (const field of filteredFields) {
 			const fieldEntries = resolveEntries({ entity, field, entries, parentEntry })

--- a/src/lib/Snapshot.svelte.ts
+++ b/src/lib/Snapshot.svelte.ts
@@ -20,6 +20,7 @@ import {
 } from '$lib/pocketbase/collections'
 import { self } from '$lib/pocketbase/managers'
 import type { Snapshot } from './common/models/Snapshot'
+import { collect_referenced_upload_ids } from './common/upload-references'
 import { instance } from './instance'
 import { usePageData } from './PageData.svelte'
 import { useSvelteWorker } from './workers/Worker.svelte'
@@ -39,6 +40,11 @@ export const useSiteSnapshot = ({ source_manager = self, source_site_id }: { sou
 					.then((res) => res.blob())
 					.then((blob) => new File([blob], filename))
 
+			// Only pack uploads the content actually references. Orphaned and
+			// duplicate upload records (e.g. from repeated image edits) would
+			// otherwise bloat snapshot.bin past the site_snapshots file limit.
+			const referenced_upload_ids = collect_referenced_upload_ids(data)
+
 			const snapshot: Snapshot = {
 				metadata: {
 					created_at: new Date().toISOString(),
@@ -48,10 +54,12 @@ export const useSiteSnapshot = ({ source_manager = self, source_site_id }: { sou
 				records: {
 					sites: [source_site.values()],
 					site_uploads: await Promise.all(
-						data.site_uploads.map(async (upload) => ({
-							...upload.values(),
-							file: typeof upload.file === 'string' ? await download('site_uploads', upload.id, upload.file) : upload.file
-						}))
+						data.site_uploads
+							.filter((upload) => referenced_upload_ids.has(upload.id))
+							.map(async (upload) => ({
+								...upload.values(),
+								file: typeof upload.file === 'string' ? await download('site_uploads', upload.id, upload.file) : upload.file
+							}))
 					),
 					site_fields: data.site_fields.map((upload) => upload.values()),
 					site_entries: data.site_entries.map((upload) => upload.values()),

--- a/src/lib/builder/field-types/ImageField.svelte
+++ b/src/lib/builder/field-types/ImageField.svelte
@@ -38,7 +38,13 @@
 		height: null
 	}
 
-	const entry = $derived(passedEntry || { value: default_value }) as Omit<Entry, 'value'> & { value: ImageFieldValue }
+	// Guard the value, not just the entry: legacy/empty image entries can have a null
+	// or non-object `value`, which would make every `entry.value.X` access below throw.
+	const entry = $derived.by(() => {
+		const base = passedEntry || { value: default_value }
+		const value = base.value && typeof base.value === 'object' ? { ...default_value, ...base.value } : default_value
+		return { ...base, value }
+	}) as Omit<Entry, 'value'> & { value: ImageFieldValue }
 	const { value: site } = site_context.getOr({ value: null })
 
 	// Helper function to extract image dimensions
@@ -95,12 +101,18 @@
 			// Extract dimensions from the compressed/final image
 			const dimensions = await get_image_dimensions(file_to_upload)
 
-			// Always create a new upload record instead of updating the existing one in place.
-			// Upload records can be shared by multiple entries (copied sections, duplicated
-			// repeater items, cloned sites), so an in-place update would change the image
-			// everywhere the record is referenced.
+			// Reuse the existing upload record in place when the field already has
+			// one, so re-cropping/replacing an image doesn't spawn an orphan record
+			// on every edit. Site clones copy uploads (each clone gets its own
+			// records), so this only shares within duplicated sections/repeater
+			// items in the same site — an accepted trade for not accumulating
+			// orphans that eventually bloat the publish snapshot.
 			let upload_record
-			if (site) {
+			if (upload && site) {
+				upload_record = SiteUploads.update(upload.id, { file: file_to_upload })
+			} else if (upload) {
+				upload_record = LibraryUploads.update(upload.id, { file: file_to_upload })
+			} else if (site) {
 				upload_record = SiteUploads.create({ file: file_to_upload, site: site.id })
 			} else {
 				upload_record = LibraryUploads.create({ file: file_to_upload })

--- a/src/lib/common/upload-references.ts
+++ b/src/lib/common/upload-references.ts
@@ -1,0 +1,51 @@
+/**
+ * Collect the upload ids a site's content actually references, so the snapshot
+ * builder can pack only those files instead of every upload record for the site
+ * (which includes orphaned and duplicate uploads). See Snapshot.svelte.ts.
+ *
+ * Image-field entries store the reference as `value.upload = <upload_id>`.
+ * Repeater and group children are flat entries with their own value, so a plain
+ * walk over every entry value catches nested images too.
+ *
+ * Note: rich-text / markdown / symbol-CSS images embedded as a raw file URL
+ * (rather than an id) are not traced here. A snapshot missing such a file only
+ * degrades a restored copy of the site, never the published site itself, so the
+ * simpler id-only trace is the intentional trade-off.
+ */
+
+const collect = (value: unknown, ids: Set<string>) => {
+	if (value == null || typeof value !== 'object') return
+	if (Array.isArray(value)) {
+		for (const item of value) collect(item, ids)
+		return
+	}
+	const record = value as Record<string, unknown>
+	if (typeof record.upload === 'string' && record.upload) ids.add(record.upload)
+	for (const key in record) collect(record[key], ids)
+}
+
+/**
+ * `data` is the assembled site data (PageData.svelte.ts). Returns the set of
+ * upload ids referenced by any entry across the site's content.
+ */
+export const collect_referenced_upload_ids = (data: {
+	site_entries?: Array<{ value?: unknown }> | null
+	page_entries?: Array<{ value?: unknown }> | null
+	page_section_entries?: Array<{ value?: unknown }> | null
+	page_type_entries?: Array<{ value?: unknown }> | null
+	page_type_section_entries?: Array<{ value?: unknown }> | null
+	symbol_entries?: Array<{ value?: unknown }> | null
+}): Set<string> => {
+	const ids = new Set<string>()
+	for (const entries of [
+		data.site_entries,
+		data.page_entries,
+		data.page_section_entries,
+		data.page_type_entries,
+		data.page_type_section_entries,
+		data.symbol_entries
+	]) {
+		for (const entry of entries ?? []) collect(entry.value, ids)
+	}
+	return ids
+}


### PR DESCRIPTION
Two independent fixes (see individual commits).

## Sort repeater subfields by index on render and export (`d281326d`)
Fields reach the render and export paths in DB insertion order, which diverges from `index` order after a subfield reorder or a CLI re-import upsert (import updates `index` but reuses the existing record, preserving its old rowid). The editor form view re-sorts by `index` everywhere, so the **published page** and **exported YAML** were the only surfaces showing subfields out of order.

- `Content.svelte.ts`: sort `filteredFields` by index in `getContent` (fixes live render — repeater subfields, group subfields, top-level fields).
- `export.go`: sort repeater items and multi-entry list fields by index in `buildSectionContent` (fixes `primo pull` / ZIP export ordering; the fix lives inside the function so it covers all four call sites).

Importer needs no change — it already assigns correct `index` from file position; the data was correct-but-unsorted.

## Pack only referenced uploads into snapshots; stop persisting null image entries (`aa1dd08f`)
Orphaned/duplicate upload records were bloating `snapshot.bin` past the `site_snapshots` file limit.

- `upload-references.ts` (new) + `Snapshot.svelte.ts`: trace the upload ids content actually references and pack only those.
- `ImageField.svelte`: reuse the existing upload record in place instead of spawning a new one per edit; guard against null/non-object `value` so empty image entries don't throw.
- `import.go`: skip persisting null-valued simple entries.

> [!NOTE]
> **Behavioral tradeoff to confirm:** the ImageField reuse-in-place change reverses a prior deliberate decision. Re-cropping an image in one duplicated repeater item now changes it in all copies **within the same site** (site clones still copy uploads). Called out in case a reviewer wants that reconsidered.

## Testing
- `go build ./internal/...` clean; `go test ./internal/...` — all pass except the pre-existing `TestUpdatedTimestampStableOnNoOpReimport` (verified failing on `main` without these changes; unrelated timestamp/ID-stability issue).
- `svelte-check`: no new errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported content now keeps repeated items and list values in a consistent, predictable order, improving YAML output stability.
  * Snapshots now include only uploads actually referenced by your content, reducing unnecessary bundled data.
* **Bug Fixes**
  * Importing no longer saves empty optional simple-field values, preventing noisy round-trips and editor issues.
  * Content rendering now respects field ordering by index for more consistent subfield/repeater behavior.
  * Image fields are more resilient to legacy/empty entries and avoid crashes.
  * Image uploads now update existing records when possible instead of always creating new ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->