### PR TITLE
Remove dead SSH deploy jobs from CI (prod + testing)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build Docker image and deploy testing
+name: Build and push Docker image (branches)
 
 on:
   workflow_dispatch:
@@ -64,29 +64,9 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-  deploy-testing:
-    runs-on: ubuntu-latest
-    needs:
-      - build-image
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up SSH
-        run: |
-          install -m 600 -D /dev/null ~/.ssh/id
-          echo "${{ secrets.TESTING_SSH_PRIVATE_KEY }}" > ~/.ssh/id
-          echo "${{ secrets.TESTING_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-
-      - name: Deploy to server
-        env:
-          DOCKER_HOST: ${{ secrets.TESTING_DOCKER_HOST }}
-          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-image.outputs.version }}
-        run: |
-          cd ./deployment/testing/
-          eval "$(ssh-agent -s)"
-          ssh-add ~/.ssh/id
-          docker compose up --pull always --detach
+  # NOTE: the former `deploy-testing` job was removed. It SSHed to
+  # TESTING_DOCKER_HOST (the retired palacms.com box) and ran `docker compose
+  # up`, so it failed on every push to main — turning otherwise-green runs red
+  # and masking real failures. build-image above still publishes the branch
+  # image to ghcr (e.g. :main), which is what Railway/testing consumers pull.
+  # Re-add a deploy job only if a new SSH-deployable host is introduced.

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: Build Docker image and deploy production
+name: Build and push Docker image
 
 on:
   push:
@@ -65,28 +65,9 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-  deploy-production:
-    runs-on: ubuntu-latest
-    needs:
-      - build-image
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up SSH
-        run: |
-          install -m 600 -D /dev/null ~/.ssh/id
-          echo "${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}" > ~/.ssh/id
-          echo "${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-
-      - name: Deploy to server
-        env:
-          DOCKER_HOST: ${{ secrets.PRODUCTION_DOCKER_HOST }}
-          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-image.outputs.version }}
-        run: |
-          cd ./deployment/production/
-          eval "$(ssh-agent -s)"
-          ssh-add ~/.ssh/id
-          docker compose up --pull always --detach
+  # NOTE: the former `deploy-production` job was removed. It SSHed to
+  # PRODUCTION_DOCKER_HOST (palacms.com, the retired Hostinger box) and ran
+  # `docker compose up`, but that host is decommissioned — it now just 301s to
+  # primo.build — so the job failed on every v3.* tag. Infra moved to Railway,
+  # which pulls the image published above on its own trigger. Re-add a deploy
+  # job here only if a new SSH-deployable host is introduced.


### PR DESCRIPTION
## What
Removes both SSH-based deploy jobs that target the retired `palacms.com` host:
- `deploy-production` from `tag.yml` (ran on `v3.*` tags)
- `deploy-testing` from `main.yml` (ran on push to `main` / feature / rc branches)

Keeps `build-image` in both workflows — images are still built and pushed to ghcr (versioned tags on release, `:main`/branch tags on push).

## Why
Both jobs SSHed to `*_DOCKER_HOST` secrets pointing at **`palacms.com`** — the retired Hostinger box from before the Pala→Primo rename. Verified: `palacms.com` now 301s to `primo.build` and its SSH (port 22) is unreachable. So:
- `deploy-production` failed on **every** release tag (v3.2.1, v3.2.2, v3.2.3).
- `deploy-testing` failed on **every** push to `main` — turning otherwise-green runs red and masking real failures.

Infra moved to Railway, which pulls the published ghcr image on its own; neither SSH `docker compose` step is how anything deploys anymore.

## Orphaned after this (no code refs; clean up separately if desired)
- Secrets: `PRODUCTION_DOCKER_HOST`, `PRODUCTION_SSH_PRIVATE_KEY`, `PRODUCTION_SSH_KNOWN_HOSTS`, `TESTING_DOCKER_HOST`, `TESTING_SSH_PRIVATE_KEY`, `TESTING_SSH_KNOWN_HOSTS`
- `deployment/production/compose.yaml`, `deployment/testing/compose.yaml` (left in place)

## Related
- #1197 — points Railway deployers at `:latest` (the tag that actually tracks releases) instead of `:main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)