### PR TITLE
Move version out of editor toolbar into profile popover

### DIFF
--- a/src/lib/builder/views/editor/Toolbar.svelte
+++ b/src/lib/builder/views/editor/Toolbar.svelte
@@ -334,7 +334,6 @@
 				<ToolbarButton id="redo" title="Redo" icon="material-symbols:redo" style="border: 0; font-size: 1.5rem;" on:click={redo_change} />
 			{/if} -->
 			<div id="primo-dev-indicator-slot"></div>
-			<span class="version-badge">{instance.version}</span>
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger>
 					{#snippet child({ props })}
@@ -505,8 +504,4 @@
 		border-radius: var(--primo-border-radius);
 	}
 
-	.version-badge {
-		font-size: 0.625rem;
-		color: #555;
-	}
 </style>

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -244,6 +244,10 @@
 								<LogOut />
 								Log out
 							</DropdownMenu.Item>
+							{#if instance.version}
+								<DropdownMenu.Separator />
+								<div class="px-2 py-1 text-[0.625rem] text-muted-foreground select-text">Primo {instance.version}</div>
+							{/if}
 						</DropdownMenu.Content>
 					</DropdownMenu.Root>
 				</Sidebar.MenuItem>


### PR DESCRIPTION
## What
- Removes the `version-badge` span (and its CSS) from the editor toolbar, where it sat next to the publish controls.
- Adds the version as a subtle muted line ("Primo &lt;version&gt;") at the bottom of the profile dropdown in the dashboard sidebar (after Log out).

## Why
The badge was showing "main" — `instance.version` comes from the build's `PRIMO_VERSION` (`github.head_ref || github.ref_name`), which is the branch name on non-tag builds. It was prominent but not useful there; the profile popover is a more natural, subtle home.

## Note (not fixed here)
The label still reflects however the instance was built — tag builds show `v3.2.3`, branch builds show `main`. So this makes it subtle but doesn't change where the value comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the version badge from the editor toolbar.
  * Added a version label in the user dropdown menu when a version is available, shown as “Primo {version}” after logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->