### PR TITLE
Pin :latest tag explicitly; document Railway :latest for auto-updates

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,6 +39,10 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            # Explicit :latest — Railway/self-host deployers follow this tag to
+            # track releases. metadata-action adds it implicitly for semver, but
+            # pin it here so it can't silently stop updating.
+            type=raw,value=latest
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ docker run -d -p 8080:8080 -v primo-data:/app/pb_data ghcr.io/primocms/primo:lat
 
 Then open your server's URL to create your first site.
 
+> **Auto-updates on Railway:** point your service's image at `ghcr.io/primocms/primo:latest` so "auto-update to the latest tag" tracks releases. If you deployed before this note and your source image is `:main`, switch it to `:latest` — `:main` is a rolling branch build, not a release, so it won't advance on version releases.
+
 **Next steps:**
 1. **[Quickstart](https://docs.primo.build/getting-started/quickstart)** — key concepts
 2. **[Build your first site](https://docs.primo.build/building-sites/your-first-site)**


### PR DESCRIPTION
## What
- `tag.yml`: add `type=raw,value=latest` so the release workflow publishes `:latest` **explicitly** (it's currently added only implicitly by `docker/metadata-action`'s semver default).
- `README.md`: note telling Railway/self-host deployers to follow `ghcr.io/primocms/primo:latest`, and to switch off `:main` if they deployed before.

## Why
Railway's "auto-update to latest tag" only works if the service tracks a tag that advances on releases. The Railway one-click template points services at **`:main`** — a rolling build produced by `main.yml` on every push to `main`, *not* a release. Consequences for anyone who deployed via the button:
- releases (e.g. v3.2.3) never reach them,
- their instance auto-updates to bleeding-edge main commits instead,
- the version label reads "main".

`:latest` already tracks releases (verified: `:latest`, `:3`, `:3.2`, `:3.2.3` all share one digest; `:main` is a different digest). This PR makes `:latest` guaranteed rather than implicit, and documents the correct tag.

## Not in this PR (requires dashboard access — yours to do)
- **Railway template**: change the one-click deploy template's source image from `:main` → `:latest` so *new* button deploys track releases. This lives in Railway's template settings, not the repo.
- **Existing services** (incl. our own) each need their source image switched `:main` → `:latest` in their own Railway dashboard — can't be done for them from here.

Related: #1195 removes the dead SSH deploy job from this same workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `latest` image tag for new releases, making it easier to track the most recent stable version.

* **Documentation**
  * Updated the Quickstart guide with guidance for enabling automatic updates on Railway using the `latest` image tag.
  * Clarified that the `main` tag follows ongoing branch builds and does not move with release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->