### PR TITLE
Ignore local-only internal/SPEC-*.md design specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ landing-page-full.png
 # Docs
 docs/
 bugs.md
+
+# Local-only internal design specs (kept out of version control)
+internal/SPEC-*.md


### PR DESCRIPTION
Keeps working design notes under `internal/` (e.g. `internal/SPEC-layout-body-sections.md`) out of version control so they don't show up as untracked. Local-only by convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to keep internal design/spec markdown files out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->