### PR TITLE
Harden on-page repeater matching against entry reorder

### DIFF
--- a/src/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/src/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -174,7 +174,16 @@
 			// Check if all elements are already matched
 			if (matched_elements.size === valid_elements.length) break
 
-			const relevant_entries = entries.filter((e) => e.field === field.id)
+			// The on-page matcher binds each entry to the next data-key element positionally,
+			// so entries must be consumed in render order. For repeater subfields the render
+			// order is the parent row-item's index (the leaf's own index is always 0), so sort
+			// by parent index first, then the entry's own index. Without this, subfields mis-bind
+			// to the wrong row after a reorder or CLI re-import (storage order != index order).
+			const entry_index = new Map(entries.map((e) => [e.id, e.index]))
+			const render_index = (e) => (e.parent ? entry_index.get(e.parent) ?? 0 : e.index)
+			const relevant_entries = entries
+				.filter((e) => e.field === field.id)
+				.sort((a, b) => render_index(a) - render_index(b) || a.index - b.index)
 			for (const entry of relevant_entries) {
 				search_elements_for_value({
 					id: entry.id,

--- a/src/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/src/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -175,15 +175,31 @@
 			if (matched_elements.size === valid_elements.length) break
 
 			// The on-page matcher binds each entry to the next data-key element positionally,
-			// so entries must be consumed in render order. For repeater subfields the render
-			// order is the parent row-item's index (the leaf's own index is always 0), so sort
-			// by parent index first, then the entry's own index. Without this, subfields mis-bind
-			// to the wrong row after a reorder or CLI re-import (storage order != index order).
-			const entry_index = new Map(entries.map((e) => [e.id, e.index]))
-			const render_index = (e) => (e.parent ? entry_index.get(e.parent) ?? 0 : e.index)
+			// so entries must be consumed in render order. A repeater subfield's own index is
+			// always 0; its render position comes from its ancestor row-items' indices. Build the
+			// full root→leaf index path for each entry and sort lexicographically by it, so leaves
+			// under different (and nested) rows can't collide. Without this, subfields mis-bind to
+			// the wrong row after a reorder or CLI re-import (storage order != index order).
+			const entry_by_id = new Map(entries.map((e) => [e.id, e]))
+			const render_path = (e) => {
+				const path: number[] = []
+				const seen = new Set()
+				for (let cur = e; cur && !seen.has(cur.id); cur = cur.parent ? entry_by_id.get(cur.parent) : undefined) {
+					seen.add(cur.id)
+					path.unshift(cur.index)
+				}
+				return path
+			}
+			const compare_paths = (a, b) => {
+				for (let i = 0; i < Math.min(a.length, b.length); i++) {
+					if (a[i] !== b[i]) return a[i] - b[i]
+				}
+				return a.length - b.length
+			}
+			const path_by_id = new Map(entries.map((e) => [e.id, render_path(e)]))
 			const relevant_entries = entries
 				.filter((e) => e.field === field.id)
-				.sort((a, b) => render_index(a) - render_index(b) || a.index - b.index)
+				.sort((a, b) => compare_paths(path_by_id.get(a.id), path_by_id.get(b.id)))
 			for (const entry of relevant_entries) {
 				search_elements_for_value({
 					id: entry.id,


### PR DESCRIPTION
## What

The on-page editor matches rendered `data-key` elements to entries **positionally** (`ComponentNode.svelte`, `make_content_editable`): for each field it walks `entries.filter(e => e.field === field.id)` and binds each entry to the next unmatched element in DOM order. Nothing ties an element to a specific repeater item, so the binding is correct only when the filtered entries happen to arrive in render order.

That assumption breaks for repeater subfields. The render order of rows is the **parent row-item's `index`**, but:
- the leaf subfield entry's own `index` is always `0` (one subfield value per item), and
- `entries` reach this path in DB insertion (rowid) order, which diverges from `index` order after a row reorder or a CLI re-import upsert.

When storage order and render order disagree, an on-page edit to a repeater subfield binds to the **wrong row** and appears to revert.

## Fix

Sort the filtered entries into render order before matching — by the parent row-item's `index` first (looked up from the entry set), then the entry's own `index` as a tiebreak for non-repeater fields:

```js
const entry_index = new Map(entries.map((e) => [e.id, e.index]))
const render_index = (e) => (e.parent ? entry_index.get(e.parent) ?? 0 : e.index)
const relevant_entries = entries
  .filter((e) => e.field === field.id)
  .sort((a, b) => render_index(a) - render_index(b) || a.index - b.index)
```

This is the editor-side complement to the render/export ordering already merged in #1194 (which sorts subfields by index on render and export). Together they make repeater ordering consistent across render, export, and on-page editing.

## Scope / caveats

- One file, no behavior change for non-repeater fields (they fall back to their own `index`).
- Correctness hardening: it makes positional matching robust when storage order ≠ index order. It does **not** add per-item identity to the DOM, so a component template that filters or reorders items client-side (`{#each rows.filter(...)}`) can still diverge — that would need item identity encoded into the rendered markup (a larger change).
- `svelte-check`: no new errors in the changed block (pre-existing repo errors elsewhere are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field rendering order in the editor so repeater subfields stay matched to the correct on-screen elements after reordering or re-importing content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->