### PR TITLE
Enable daily backups by default on fresh deploys

### DIFF
--- a/migrations/1757326540_settings.go
+++ b/migrations/1757326540_settings.go
@@ -32,7 +32,9 @@ func init() {
 				settings.Backups.CronMaxKeep = 7
 			}
 
-			app.Save(settings)
+			if err := app.Save(settings); err != nil {
+				return err
+			}
 
 			superuserEmail := os.Getenv("PRIMO_SUPERUSER_EMAIL")
 			superuserPassword := os.Getenv("PRIMO_SUPERUSER_PASSWORD")

--- a/migrations/1757326540_settings.go
+++ b/migrations/1757326540_settings.go
@@ -17,6 +17,21 @@ func init() {
 			}
 
 			settings.Meta.AppName = "Primo CMS"
+
+			// Enable automatic backups by default so a fresh deploy isn't one
+			// volume wipe away from total data loss. Stored on the pb_data
+			// volume (backups/ dir) — a floor, not off-site protection; wire up
+			// Backups.S3 for that. Env-overridable; only set when unconfigured
+			// so we never clobber a schedule set via the admin UI.
+			if settings.Backups.Cron == "" {
+				cron := os.Getenv("PRIMO_BACKUP_CRON")
+				if cron == "" {
+					cron = "0 3 * * *" // daily at 03:00
+				}
+				settings.Backups.Cron = cron
+				settings.Backups.CronMaxKeep = 7
+			}
+
 			app.Save(settings)
 
 			superuserEmail := os.Getenv("PRIMO_SUPERUSER_EMAIL")


### PR DESCRIPTION
## What

Sets a default backup schedule when none is configured, so a fresh deploy isn't one volume wipe away from total data loss.

- Cron `0 3 * * *` (daily at 03:00), `CronMaxKeep = 7`, applied in the settings migration.
- Overridable via `PRIMO_BACKUP_CRON`.
- Only set when `settings.Backups.Cron` is empty, so a schedule configured through the admin UI is never clobbered.

## Caveat

Backups land on the `pb_data` volume (`backups/` dir) — a floor, not off-site protection. For durable backups, configure `Backups.S3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic backups are now enabled by default during setup.
  * A default backup schedule is applied when none is configured, with a sensible retention limit.
* **Bug Fixes**
  * Existing setup behavior remains unchanged aside from the new backup defaults, helping ensure fresh installs start with backups configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->