### PR TITLE
Make file→CMS upload sync idempotent

### DIFF
--- a/internal/bootstrap.go
+++ b/internal/bootstrap.go
@@ -146,12 +146,19 @@ func handleBootstrap(pb *pocketbase.PocketBase, e *core.RequestEvent) error {
 			return e.InternalServerError("Import failed: "+err.Error(), err)
 		}
 
+		// created_ids carries the uploads manifest (canonical suffixed
+		// filenames + record ids) the CLI needs to rename local files and
+		// rewrite symbolic `upload: uploads/...` refs. Dropping it here made
+		// the first (bootstrap) push skip writeback, so the CLI kept re-sending
+		// un-suffixed names on every later push — see the upload dedup fix in
+		// import.go's reconcileSiteUploads.
 		return e.JSON(200, map[string]interface{}{
-			"success":  true,
-			"site_id":  siteId,
-			"name":     siteName,
-			"host":     siteHost,
-			"warnings": result.Warnings,
+			"success":     true,
+			"site_id":     siteId,
+			"name":        siteName,
+			"host":        siteHost,
+			"warnings":    result.Warnings,
+			"created_ids": result.CreatedIDs,
 		})
 	}
 

--- a/internal/import.go
+++ b/internal/import.go
@@ -3497,7 +3497,7 @@ func upsertSiteUpload(
 		// stacking bug). Storage is keyed by collection id, not name.
 		storedName := existing.GetString("file")
 		sourceKey := uploadsColl.Id + "/" + existing.Id + "/" + storedName
-		reader, readErr := fsys.GetFile(sourceKey)
+		reader, readErr := fsys.GetReader(sourceKey)
 		if readErr == nil {
 			existingBytes, _ := io.ReadAll(reader)
 			reader.Close()
@@ -3626,7 +3626,7 @@ func reconcileSiteUploads(app core.App, site *core.Record, files map[string][]by
 		if fn == "" {
 			continue
 		}
-		reader, rerr := fsys.GetFile(uploadsColl.Id + "/" + rec.Id + "/" + fn)
+		reader, rerr := fsys.GetReader(uploadsColl.Id + "/" + rec.Id + "/" + fn)
 		if rerr != nil {
 			continue
 		}

--- a/internal/import.go
+++ b/internal/import.go
@@ -3488,14 +3488,25 @@ func upsertSiteUpload(
 			}
 			defer fsys.Close()
 		}
-		sourceKey := uploadsColl.Id + "/" + existing.Id + "/" + filename
+		// Read the currently stored bytes to see whether this is a true no-op.
+		// The storage path is keyed by the record's ACTUAL stored filename
+		// (which carries PocketBase's random suffix), NOT by the caller-supplied
+		// `filename` — those differ whenever the CLI re-sends a symbolic name
+		// for an already-suffixed record, and using `filename` here would miss
+		// the file, fall through, and re-suffix on every push (the duplicate-
+		// stacking bug). Storage is keyed by collection id, not name.
+		storedName := existing.GetString("file")
+		sourceKey := uploadsColl.Id + "/" + existing.Id + "/" + storedName
 		reader, readErr := fsys.GetFile(sourceKey)
 		if readErr == nil {
 			existingBytes, _ := io.ReadAll(reader)
 			reader.Close()
 			existingHash := sha256.Sum256(existingBytes)
 			if hex.EncodeToString(existingHash[:]) == incomingHex {
-				return uploadReconcileEntry{ID: existing.Id, Canonical: filename, Hash: incomingHex}, false, nil
+				// Unchanged bytes → no-op. Return the stored (already-suffixed)
+				// name as canonical so the CLI keeps the local file on that name
+				// instead of chasing a fresh suffix each push.
+				return uploadReconcileEntry{ID: existing.Id, Canonical: storedName, Hash: incomingHex}, false, nil
 			}
 		}
 
@@ -3597,8 +3608,49 @@ func reconcileSiteUploads(app core.App, site *core.Record, files map[string][]by
 	}
 	defer fsys.Close()
 
+	// Index existing records by the CONTENT HASH of their stored bytes. This is
+	// the stable identity a push should match on: filenames carry a random
+	// PocketBase suffix that changes on every write, so keying only by filename
+	// meant a re-sent symbolic name (`favicon.svg`) never matched its already-
+	// suffixed record (`favicon_ab12cd34.svg`) and got recreated + re-suffixed
+	// on every push — turning one image into N byte-identical orphans. Matching
+	// by hash makes an unchanged image a no-op regardless of the name sent.
+	//
+	// Reading every stored upload once per push is the cost of not persisting a
+	// hash column; it's bounded by the site's upload count and the bytes are
+	// small relative to the zip we already decompressed. A read failure just
+	// leaves that record out of the hash index — it can still match by filename.
+	existingByHash := make(map[string]*core.Record, len(existing))
+	for _, rec := range existing {
+		fn := rec.GetString("file")
+		if fn == "" {
+			continue
+		}
+		reader, rerr := fsys.GetFile(uploadsColl.Id + "/" + rec.Id + "/" + fn)
+		if rerr != nil {
+			continue
+		}
+		b, _ := io.ReadAll(reader)
+		reader.Close()
+		sum := sha256.Sum256(b)
+		hexSum := hex.EncodeToString(sum[:])
+		// First writer wins on hash collision (byte-identical duplicates that
+		// this very bug may have already created); the loser stays reachable by
+		// filename and is a candidate for `--prune-uploads` garbage collection.
+		if _, seen := existingByHash[hexSum]; !seen {
+			existingByHash[hexSum] = rec
+		}
+	}
+
 	for _, up := range zipUploads {
-		entry, _, err := upsertSiteUpload(app, site, up.filename, up.data, existingByFilename[up.filename], uploadsColl, fsys)
+		// Prefer a content-hash match (stable across renames) over a filename
+		// match (mutated by suffixing). Only when neither hits do we create.
+		incomingSum := sha256.Sum256(up.data)
+		match := existingByHash[hex.EncodeToString(incomingSum[:])]
+		if match == nil {
+			match = existingByFilename[up.filename]
+		}
+		entry, _, err := upsertSiteUpload(app, site, up.filename, up.data, match, uploadsColl, fsys)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/upload_idempotent_test.go
+++ b/internal/upload_idempotent_test.go
@@ -1,0 +1,125 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+// reproSiteFiles returns a minimal importable site that references a single
+// upload via a symbolic `upload: uploads/<name>` path. The upload filename is
+// parameterized so we can simulate what the CLI sends on push N (symbolic on
+// push 1, canonical on later pushes if the writeback rename worked).
+func reproSiteFiles(uploadName string, pngBytes []byte) map[string][]byte {
+	return map[string][]byte{
+		"uploads/" + uploadName:           pngBytes,
+		"blocks/hero/config.yaml":         []byte("name: hero\n"),
+		"blocks/hero/component.svelte":    []byte("<section><img src={image.url} alt={image.alt} /></section>\n"),
+		"blocks/hero/fields.yaml":         []byte("- name: image\n  label: Image\n  type: image\n"),
+		"blocks/hero/content.yaml":        []byte("{}\n"),
+		"page-types/default/config.yaml":  []byte("name: Default\nallowed_blocks:\n  - hero\n"),
+		"page-types/default/fields.yaml":  []byte("[]\n"),
+		"page-types/default/layout.yaml":  []byte("{}\n"),
+		"pages/index.yaml": []byte("" +
+			"name: Home\n" +
+			"page_type: Default\n" +
+			"sections:\n" +
+			"  - block: hero\n" +
+			"    content:\n" +
+			"      image:\n" +
+			"        url: \"\"\n" +
+			"        alt: A hero image\n" +
+			"        upload: uploads/" + uploadName + "\n"),
+		"site/fields.yaml":  []byte("[]\n"),
+		"site/content.yaml": []byte("{}\n"),
+	}
+}
+
+func canonicalFrom(t *testing.T, res *ImportResult, symbolic string) string {
+	t.Helper()
+	m, ok := res.CreatedIDs["uploads/.manifest.json"]
+	if !ok {
+		t.Fatalf("no uploads manifest in created_ids")
+	}
+	blob, ok := m["_uploads"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("no _uploads blob: %#v", m)
+	}
+	entry, ok := blob[symbolic].(map[string]interface{})
+	if !ok {
+		t.Fatalf("no entry for %q: %#v", symbolic, blob)
+	}
+	c, _ := entry["canonical"].(string)
+	return c
+}
+
+// TestUploadRepushWithCanonicalNameIsNoOp models the CORRECT CLI behavior:
+// after push 1 renames the local file to its canonical suffixed name, push 2
+// sends that canonical name. This should be a pure no-op.
+func TestUploadRepushWithCanonicalNameIsNoOp(t *testing.T) {
+	app := newImportTestApp(t)
+	defer app.ResetBootstrapState()
+	site := createImportTestSite(t, app)
+	png := fakePNG()
+
+	// Push 1: symbolic name.
+	res1, err := processImport(app, site, zipFilesBinary(t, reproSiteFiles("hero.png", png)), false)
+	if err != nil {
+		t.Fatalf("push 1: %v", err)
+	}
+	canonical := canonicalFrom(t, res1, "hero.png")
+	if !strings.HasPrefix(canonical, "hero_") {
+		t.Fatalf("expected canonical hero_xxx.png, got %q", canonical)
+	}
+	up1, _ := app.FindRecordsByFilter("site_uploads", "site = {:site}", "", 0, 0, map[string]any{"site": site.Id})
+	if len(up1) != 1 {
+		t.Fatalf("after push 1 expected 1 upload, got %d", len(up1))
+	}
+
+	// Push 2: CLI renamed the local file to `canonical`, so it now sends that.
+	// NOTE: the yaml ref would also have been rewritten to the record id, but
+	// we keep the symbolic upload key pointing at the canonical filename to
+	// isolate the upload-dedup behavior.
+	res2, err := processImport(app, site, zipFilesBinary(t, reproSiteFiles(canonical, png)), false)
+	if err != nil {
+		t.Fatalf("push 2: %v", err)
+	}
+	up2, _ := app.FindRecordsByFilter("site_uploads", "site = {:site}", "", 0, 0, map[string]any{"site": site.Id})
+	canonical2 := canonicalFrom(t, res2, canonical)
+
+	if len(up2) != 1 {
+		t.Fatalf("REPRO: push 2 with canonical name created duplicate uploads: before=1 after=%d", len(up2))
+	}
+	if canonical2 != canonical {
+		t.Fatalf("REPRO: push 2 re-suffixed the already-canonical name: %q -> %q", canonical, canonical2)
+	}
+}
+
+// TestUploadRepushWithSymbolicNameIsIdempotent guards the regression: the CLI
+// keeps sending the ORIGINAL symbolic name every push (the writeback rename
+// never took, or the yaml still resolves to the same on-disk symbolic file).
+// Before the content-hash match this stacked a fresh suffix and orphaned a new
+// site_uploads record on every push; now each push is a no-op.
+func TestUploadRepushWithSymbolicNameIsIdempotent(t *testing.T) {
+	app := newImportTestApp(t)
+	defer app.ResetBootstrapState()
+	site := createImportTestSite(t, app)
+	png := fakePNG()
+
+	var lastCanonical string
+	for i := 1; i <= 4; i++ {
+		res, err := processImport(app, site, zipFilesBinary(t, reproSiteFiles("hero.png", png)), false)
+		if err != nil {
+			t.Fatalf("push %d: %v", i, err)
+		}
+		lastCanonical = canonicalFrom(t, res, "hero.png")
+		ups, _ := app.FindRecordsByFilter("site_uploads", "site = {:site}", "", 0, 0, map[string]any{"site": site.Id})
+		t.Logf("push %d: uploads=%d canonical=%q", i, len(ups), lastCanonical)
+		if len(ups) != 1 {
+			t.Fatalf("REPRO CONFIRMED: after push %d there are %d site_uploads records for one byte-identical image (canonical=%q). Each push re-suffixed and orphaned the prior record.", i, len(ups), lastCanonical)
+		}
+	}
+	// Count underscore-delimited suffix segments after the base name.
+	if strings.Count(lastCanonical, "_") > 1 {
+		t.Fatalf("REPRO CONFIRMED: canonical name stacked multiple suffixes: %q", lastCanonical)
+	}
+}


### PR DESCRIPTION
## Problem

Every `primo dev` push re-uploaded unchanged local images instead of no-op'ing. On each push an already-canonicalized upload got **another** hash suffix appended and a **new** `site_uploads` record created server-side, orphaning the previous one. Over many pushes one image became many byte-identical duplicates (`favicon_x_y_..._z.svg` with stacked `_xxxxxxxxxx` segments); in a real site 13 images grew into 187 physical files / manifest entries, resending ~18MB per push until it hit `This operation was aborted`.

## Root cause

Upload identity was keyed on the **mutable suffixed filename**, not content:

- `reconcileSiteUploads` indexed existing records by `file` (the suffixed name). When the CLI re-sent a *symbolic* name (`favicon.svg`), it missed the record stored as `favicon_ab12cd34.svg` → fell into the **create** branch → new record, and PocketBase's `NewFileFromBytes` re-suffixed unconditionally.
- `upsertSiteUpload`'s no-op hash-read built the storage path from the **caller-supplied** `filename` instead of the record's **stored** name, and swallowed the read error — so a name mismatch silently fell through to the re-suffixing **update** branch.
- The `bootstrap` endpoint ran the full import but **dropped `created_ids`** from its response, so the CLI's first push never wrote back canonical names (kept re-sending symbolic names forever).

## Fix

- `reconcileSiteUploads` matches incoming files by **content hash** first (stable identity), filename second — an unchanged image is a no-op regardless of the name sent.
- `upsertSiteUpload` reads existing bytes by the record's **stored** filename and returns that stored name as canonical.
- `bootstrap` response now includes `created_ids`.

Paired CLI fix (makes the first push write back canonical names): primocms/primo-cli.

## Tests

`internal/upload_idempotent_test.go` — repeated pushes of a byte-identical image (both symbolic and canonical names) stay at exactly **1** record with one stable suffix. Previously the symbolic-name case stacked suffixes and created duplicates on every push.

Full `internal` suite passes (`TestUpdatedTimestampStableOnNoOpReimport` fails identically on `main` — pre-existing, unrelated to uploads).

## Follow-up (not in this PR)

The orphaned `site_uploads` records this bug already created still need a `--prune-uploads --dedupe` GC pass (group by content hash, keep the referenced/oldest record, repoint refs, delete the rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootstrap upload responses now include a `created_ids` field, improving how the CLI tracks newly created records and updates upload references.

* **Bug Fixes**
  * Re-uploads are now reliably detected as no-ops when content is unchanged, even if the provided filename differs from the stored canonical name.
  * Prevents duplicate `site_uploads` records and repeated filename suffixing on subsequent pushes.

* **Tests**
  * Added end-to-end idempotency tests covering both canonical and symbolic filename repeat uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->