### PR TITLE
Enforce plan site + per-site editor caps

### DIFF
--- a/internal/info.go
+++ b/internal/info.go
@@ -83,6 +83,15 @@ func RegisterInfoEndpoint(pb *pocketbase.PocketBase) error {
 			version := getBuildVersion()
 			smtpEnabled := pb.Settings().SMTP.Enabled
 
+			// Expose plan caps so the UI can disable the create-site / add-editor
+			// affordances and show usage. A cap of 0 means unlimited (omitted).
+			// site_count is instance-wide (site cap is instance-wide); the editor
+			// cap is per-site, so the per-site count is computed client-side from
+			// that site's role assignments rather than surfaced here.
+			siteCap := getCap(pb, "site_cap", "PRIMO_SITE_CAP")
+			editorCap := getCap(pb, "editor_cap", "PRIMO_EDITOR_CAP")
+			siteCount, _ := pb.CountRecords("sites")
+
 			return requestEvent.JSON(200, struct {
 				Id               string `json:"id"`
 				Version          string `json:"version"`
@@ -91,6 +100,9 @@ func RegisterInfoEndpoint(pb *pocketbase.PocketBase) error {
 				HostedMode       bool   `json:"hosted_mode"`
 				BillingURL       string `json:"billing_url,omitempty"`
 				DevMode          bool   `json:"dev_mode"`
+				SiteCap          int    `json:"site_cap,omitempty"`
+				SiteCount        int64  `json:"site_count"`
+				EditorCap        int    `json:"editor_cap,omitempty"`
 			}{
 				Id:               id,
 				Version:          version,
@@ -99,6 +111,9 @@ func RegisterInfoEndpoint(pb *pocketbase.PocketBase) error {
 				HostedMode:       isHostedMode(),
 				BillingURL:       os.Getenv("PRIMO_BILLING_URL"),
 				DevMode:          DevMode,
+				SiteCap:          siteCap,
+				SiteCount:        siteCount,
+				EditorCap:        editorCap,
 			})
 		})
 

--- a/internal/limits.go
+++ b/internal/limits.go
@@ -22,6 +22,15 @@ import (
 // bootstrap/settings migration that seeds the first user, and internal clones
 // run outside an API request — unaffected, since those don't go through the
 // request hook.
+//
+// The count-then-create in each hook is not atomic (TOCTOU): two truly
+// simultaneous creates can both pass the count and exceed the cap by one. We
+// accept this deliberately — these are rare, manual, single-operator actions
+// (create site / invite editor), the cap is a soft business limit rather than a
+// security boundary, and the worst case is off-by-one. A mutex across the hook
+// would serialize every create for a race that effectively can't occur at this
+// scale; if strict enforcement is ever needed, reconcile in an
+// OnRecordAfterCreate* hook instead.
 
 // getCap reads an integer cap by config_values key, falling back to an env var.
 // Returns 0 when unset/invalid, which callers treat as "unlimited".

--- a/internal/limits.go
+++ b/internal/limits.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// Plan limits for a managed (hosted) instance. Caps are read from the
+// config_values collection first (so they can be provisioned/changed per
+// instance at runtime), falling back to the PRIMO_SITE_CAP / PRIMO_EDITOR_CAP
+// env vars. A cap of 0 (or unset/unparseable) means unlimited — self-hosters
+// and anyone who hasn't provisioned a cap are never restricted.
+//
+// Enforcement lives on the record-create *request* hooks so it covers every
+// user-initiated path (dashboard direct collection writes, `primo push` /
+// import, clone) in one place, while leaving server-side provisioning — the
+// bootstrap/settings migration that seeds the first user, and internal clones
+// run outside an API request — unaffected, since those don't go through the
+// request hook.
+
+// getCap reads an integer cap by config_values key, falling back to an env var.
+// Returns 0 when unset/invalid, which callers treat as "unlimited".
+func getCap(pb *pocketbase.PocketBase, configKey, envVar string) int {
+	if collection, err := pb.FindCollectionByNameOrId("config_values"); err == nil {
+		if record, err := pb.FindFirstRecordByData(collection.Id, "key", configKey); err == nil {
+			if n, err := strconv.Atoi(record.GetString("value")); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+
+	if n, err := strconv.Atoi(os.Getenv(envVar)); err == nil && n > 0 {
+		return n
+	}
+
+	return 0
+}
+
+// RegisterSiteLimit rejects site creation once the instance is at its plan's
+// site cap. This is the high-value guard: a created site holds real content and
+// possibly a live domain, so an over-cap site is effectively impossible to claw
+// back — unlike an over-cap editor, which is a one-click removal.
+func RegisterSiteLimit(pb *pocketbase.PocketBase) error {
+	pb.OnRecordCreateRequest("sites").BindFunc(func(e *core.RecordRequestEvent) error {
+		cap := getCap(pb, "site_cap", "PRIMO_SITE_CAP")
+		if cap > 0 {
+			count, err := pb.CountRecords("sites")
+			if err != nil {
+				return err
+			}
+			if count >= int64(cap) {
+				return apis.NewBadRequestError(
+					"Site limit reached for your plan. Upgrade to add more sites.", nil)
+			}
+		}
+		return e.Next()
+	})
+
+	return nil
+}
+
+// RegisterEditorLimit rejects adding another editor to a site once that site is
+// at its plan's per-site editor cap — matching the pricing copy ("N editors per
+// site"). Editors are users linked to a site through a site_role_assignments
+// record with role "editor"; the invite flow creates exactly that record (see
+// invitation.go), so guarding its creation covers both email invites and
+// generated links. Only the "editor" role counts — developers/owners are not
+// billed editor seats. Cap of 0 means unlimited. Low risk regardless: an
+// over-cap assignment is trivially reversible.
+func RegisterEditorLimit(pb *pocketbase.PocketBase) error {
+	pb.OnRecordCreateRequest("site_role_assignments").BindFunc(func(e *core.RecordRequestEvent) error {
+		cap := getCap(pb, "editor_cap", "PRIMO_EDITOR_CAP")
+		if cap > 0 && e.Record.GetString("role") == "editor" {
+			siteId := e.Record.GetString("site")
+			count, err := pb.CountRecords("site_role_assignments",
+				dbx.HashExp{"site": siteId, "role": "editor"})
+			if err != nil {
+				return err
+			}
+			if count >= int64(cap) {
+				return apis.NewBadRequestError(
+					"Editor limit reached for this site on your plan. Upgrade to add more editors.", nil)
+			}
+		}
+		return e.Next()
+	})
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -94,6 +94,14 @@ func setup(pb *pocketbase.PocketBase) error {
 		return err
 	}
 
+	if err := internal.RegisterSiteLimit(pb); err != nil {
+		return err
+	}
+
+	if err := internal.RegisterEditorLimit(pb); err != nil {
+		return err
+	}
+
 	if err := internal.RegisterDevAuthEndpoint(pb); err != nil {
 		return err
 	}

--- a/migrations/1757326540_settings.go
+++ b/migrations/1757326540_settings.go
@@ -67,6 +67,27 @@ func init() {
 				app.Save(record)
 			}
 
+			// Seed plan caps into config_values from env so a provisioned
+			// instance enforces its tier's limits (see internal/limits.go).
+			// Only written when the env var is a positive int; absent/0 leaves
+			// the instance unlimited, which is correct for self-host.
+			for _, cap := range []struct{ envVar, key string }{
+				{"PRIMO_SITE_CAP", "site_cap"},
+				{"PRIMO_EDITOR_CAP", "editor_cap"},
+			} {
+				if os.Getenv(cap.envVar) == "" {
+					continue
+				}
+				collection, err := app.FindCollectionByNameOrId("config_values")
+				if err != nil {
+					return err
+				}
+				record := core.NewRecord(collection)
+				record.Set("key", cap.key)
+				record.Set("value", os.Getenv(cap.envVar))
+				app.Save(record)
+			}
+
 			return nil
 		},
 		func(app core.App) error {

--- a/migrations/1757326540_settings.go
+++ b/migrations/1757326540_settings.go
@@ -85,7 +85,9 @@ func init() {
 				record := core.NewRecord(collection)
 				record.Set("key", cap.key)
 				record.Set("value", os.Getenv(cap.envVar))
-				app.Save(record)
+				if err := app.Save(record); err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/src/lib/builder/views/modal/Collaboration.svelte
+++ b/src/lib/builder/views/modal/Collaboration.svelte
@@ -172,6 +172,13 @@
 			)
 	)
 	let is_remove_collaborator_open = $state(false)
+
+	// Per-site editor cap: 0/undefined means unlimited. Only "editor"-role
+	// assignments count toward it (developers are not billed editor seats).
+	// Enforced server-side in internal/limits.go; this disables the invite
+	// affordance once this site is at its plan's per-site editor limit.
+	let site_editor_count = $derived(site.role_assignments()?.filter((a) => a.role === 'editor').length ?? 0)
+	let at_editor_cap = $derived(!!instance.editor_cap && site_editor_count >= instance.editor_cap)
 	let removing_collaborator = $state(false)
 	let collaborator_to_remove = $state<{ user: User; assignment: SiteRoleAssignment }>()
 
@@ -268,7 +275,7 @@
 			</div>
 			<div>
 				{#if instance.smtp_enabled}
-					<button type="submit" value="email">
+					<button type="submit" value="email" disabled={at_editor_cap} title={at_editor_cap ? 'Editor limit reached for your plan. Upgrade to add more editors.' : undefined}>
 						{#if sending}
 							<Icon icon="eos-icons:three-dots-loading" />
 						{:else}
@@ -277,7 +284,7 @@
 					</button>
 					<span>or</span>
 				{/if}
-				<button type="submit" value="link">
+				<button type="submit" value="link" disabled={at_editor_cap} title={at_editor_cap ? 'Editor limit reached for your plan. Upgrade to add more editors.' : undefined}>
 					{#if generating}
 						<Icon icon="eos-icons:three-dots-loading" />
 					{:else}

--- a/src/lib/builder/views/modal/SitePages/SitePages.svelte
+++ b/src/lib/builder/views/modal/SitePages/SitePages.svelte
@@ -167,32 +167,32 @@
 				</div>
 			</li>
 		{/if}
-	</ul>
 
-	{#if creating_page}
-		<div class="p-2 bg-[var(--primo-color-black)]">
-			<PageForm
-				oncreate={async (new_page: any) => {
-					creating_page = false
-					const url_taken = all_pages.some((page) => page?.slug === new_page.slug && page.parent === homepage.id)
-					if (url_taken) {
-						alert(`That URL is already in use`)
-					} else {
-						building_page = true
-						building_page_name = new_page.name
-						await create_page_with_sections({ ...new_page, parent: homepage.id, site: site.id })
-					}
-				}}
-			/>
-		</div>
-	{:else}
-		<div class="p-2 bg-(--primo-color-black)">
-			<button class="create-page-btn" onclick={() => (creating_page = true)}>
-				<Icon icon="akar-icons:plus" />
-				<span>Create Page</span>
-			</button>
-		</div>
-	{/if}
+		{#if creating_page}
+			<li>
+				<PageForm
+					oncreate={async (new_page: any) => {
+						creating_page = false
+						const url_taken = all_pages.some((page) => page?.slug === new_page.slug && page.parent === homepage.id)
+						if (url_taken) {
+							alert(`That URL is already in use`)
+						} else {
+							building_page = true
+							building_page_name = new_page.name
+							await create_page_with_sections({ ...new_page, parent: homepage.id, site: site.id })
+						}
+					}}
+				/>
+			</li>
+		{:else}
+			<li>
+				<button class="create-page-btn" onclick={() => (creating_page = true)}>
+					<Icon icon="akar-icons:plus" />
+					<span>Create Page</span>
+				</button>
+			</li>
+		{/if}
+	</ul>
 {/if}
 
 <style lang="postcss">

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -8,6 +8,9 @@ export type InstanceInfo = {
 	hosted_mode: boolean
 	billing_url?: string
 	dev_mode: boolean
+	site_cap?: number
+	site_count: number
+	editor_cap?: number
 }
 
 export const instance: InstanceInfo = await fetch(new URL('/api/primo/info', self.baseURL)).then((res) => res.json())

--- a/src/routes/dashboard/sites/+page.svelte
+++ b/src/routes/dashboard/sites/+page.svelte
@@ -20,6 +20,7 @@
 	import { ClientResponseError } from 'pocketbase'
 	import { useSiteSnapshot } from '$lib/Snapshot.svelte'
 	import { Snapshot } from '$lib/common/models/Snapshot'
+	import { instance } from '$lib/instance'
 
 	const sidebar = useSidebar()
 
@@ -36,6 +37,10 @@
 	const active_site_group = $derived(site_group_id ? SiteGroups.one(site_group_id) : undefined)
 	const all_sites = $derived(Sites.list() ?? [])
 	const sites = $derived(site_group_id ? all_sites.filter((site) => site.group === site_group_id) : [])
+
+	// Plan site cap: 0/undefined means unlimited. Enforced server-side in
+	// internal/limits.go; this just disables the affordance + shows usage.
+	const at_site_cap = $derived(!!instance.site_cap && all_sites.length >= instance.site_cap)
 
 	let is_rename_group_open = $state(false)
 	let new_group_name = $state('')
@@ -195,10 +200,15 @@
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</div>
-	<div class="ml-auto mr-4">
+	<div class="ml-auto mr-4 flex items-center gap-3">
+		{#if instance.site_cap}
+			<span class="text-xs text-muted-foreground">{all_sites.length} of {instance.site_cap} sites</span>
+		{/if}
 		<Button
 			size="sm"
 			variant="outline"
+			disabled={at_site_cap}
+			title={at_site_cap ? 'Site limit reached for your plan. Upgrade to add more sites.' : undefined}
 			onclick={() => {
 				if (all_sites.some((site) => site.host === page.url.host)) {
 					is_create_site_instructions_open = true


### PR DESCRIPTION
Adds plan-limit enforcement so a hosted instance can't exceed its tier's site/editor allowances — the site cap especially, since an over-cap site (real content + possibly a live domain) is effectively impossible to claw back after the fact.

## What it does
- **Site cap (instance-wide):** rejects site creation once the instance is at `site_cap`. Enforced on the `sites` record-create *request* hook, so it covers the dashboard, `primo push`/import, and clone in one place. Server-side provisioning/bootstrap isn't affected (it doesn't go through the request hook).
- **Editor cap (per-site):** rejects adding another `editor`-role `site_role_assignments` record once a site is at `editor_cap` — matching the pricing copy ("N editors *per site*"). Only the `editor` role counts; developers/owners don't consume editor seats. Covers both email invites and generated links (both create that record).
- **Caps source:** read from the `config_values` collection first, falling back to `PRIMO_SITE_CAP` / `PRIMO_EDITOR_CAP` env vars. **A cap of 0 / unset means unlimited**, so self-hosters are never restricted.
- **Provisioning:** the settings migration seeds `site_cap`/`editor_cap` into `config_values` from env at first boot, mirroring the existing account-creation seeding.
- **UI:** `/api/primo/info` now returns `site_cap`, `site_count`, `editor_cap`. The dashboard disables **Create Site** (with an "N of M sites" hint) at the site cap, and the Collaboration modal disables a site's invite buttons at its per-site editor cap. Server hooks remain the source of truth — the UI is UX only.

## Notes
- Also includes a small UI tweak: the **Create Page** button now renders at the bottom of the page list (its own commit).
- Verified: `go build ./...` + `go vet ./internal/...` clean; `svelte-check` clean on all changed files (remaining repo `svelte-check` errors are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plan-based limits for creating sites and inviting editors, enforced automatically during record creation.
  * Instance details now expose plan capability metadata, including site capacity and current site count.
  * Site dashboard shows usage (current vs. cap) and disables “Create Site” when the limit is reached.
  * Collaboration modal disables editor invite and link generation once the editor cap is reached, with an explanatory tooltip.
* **Style**
  * Refreshed the “create page” UI to render the form/action directly within the page list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->