### PR TITLE
Add compiled_html_hash + compiled_js_hash for incremental publish

### DIFF
--- a/migrations/1783400000_symbol_compiled_js_hash.go
+++ b/migrations/1783400000_symbol_compiled_js_hash.go
@@ -1,0 +1,48 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// The publish compiler recompiles every symbol's client bundle on every
+// publish, even when the symbol's source is unchanged. Storing a hash of the
+// compile input alongside compiled_js lets the compiler skip the esbuild +
+// svelte pass (and the re-upload) when nothing about the symbol changed.
+// Existing rows have compiled_js_hash empty and are recompiled once, which
+// populates the hash; subsequent no-op publishes then skip them.
+func init() {
+	m.Register(
+		func(app core.App) error {
+			collection, err := app.FindCollectionByNameOrId("site_symbols")
+			if err != nil {
+				return err
+			}
+
+			if collection.Fields.GetByName("compiled_js_hash") != nil {
+				return nil
+			}
+
+			collection.Fields.Add(&core.TextField{
+				Name: "compiled_js_hash",
+				Max:  100,
+			})
+
+			return app.Save(collection)
+		},
+		func(app core.App) error {
+			collection, err := app.FindCollectionByNameOrId("site_symbols")
+			if err != nil {
+				return err
+			}
+
+			field := collection.Fields.GetByName("compiled_js_hash")
+			if field == nil {
+				return nil
+			}
+
+			collection.Fields.RemoveById(field.GetId())
+			return app.Save(collection)
+		},
+	)
+}

--- a/migrations/1783400001_page_compiled_html_hash.go
+++ b/migrations/1783400001_page_compiled_html_hash.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// The publish compiler re-renders every page on every publish, even when
+// nothing that affects a page's HTML changed. Storing a hash of the page's
+// effective input (its content + the hashes of the symbols/layout it depends
+// on) alongside compiled_html lets the compiler skip the server-side render
+// and re-upload for unchanged pages. Existing rows have compiled_html_hash
+// empty and are re-rendered once, which populates the hash; subsequent no-op
+// publishes then skip them. See 1783400000_symbol_compiled_js_hash.go for the
+// symbol-level counterpart whose hashes this folds in.
+func init() {
+	m.Register(
+		func(app core.App) error {
+			collection, err := app.FindCollectionByNameOrId("pages")
+			if err != nil {
+				return err
+			}
+
+			if collection.Fields.GetByName("compiled_html_hash") != nil {
+				return nil
+			}
+
+			collection.Fields.Add(&core.TextField{
+				Name: "compiled_html_hash",
+				Max:  100,
+			})
+
+			return app.Save(collection)
+		},
+		func(app core.App) error {
+			collection, err := app.FindCollectionByNameOrId("pages")
+			if err != nil {
+				return err
+			}
+
+			field := collection.Fields.GetByName("compiled_html_hash")
+			if field == nil {
+				return nil
+			}
+
+			collection.Fields.RemoveById(field.GetId())
+			return app.Save(collection)
+		},
+	)
+}


### PR DESCRIPTION
Adds two text fields — `compiled_js_hash` on `site_symbols` and `compiled_html_hash` on `pages` — stored alongside the existing `compiled_js` / `compiled_html` artifacts.

## Why
The publish compiler currently recompiles every symbol bundle and re-renders every page on every publish, even when nothing that affects the output changed. Storing a hash of each artifact's effective input lets the compiler skip the expensive esbuild + svelte compile / SSR render (and the re-upload) for unchanged records.

- Existing rows start with an empty hash → recompile once → hash populated → subsequent no-op publishes skip them.
- Migrations are idempotent (guarded on field existence) with working up **and** down.

## Context
This is the **server half** of the incremental-publish feature. The compiler that reads/writes these hashes lives in **primo-mcp** (`publish_compiler.ts`, currently a WIP commit). This migration is a no-op on its own and must land before that MCP change does anything. Perf optimization — publish already works via full recompile; not a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking compiled JavaScript changes for site symbols.
  * Added support for tracking compiled HTML changes for pages.
  * These updates improve detection of content changes during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->