### PR TITLE
Add "Develop locally" affordance to the dashboard

### DIFF
--- a/src/routes/dashboard/sites/+page.svelte
+++ b/src/routes/dashboard/sites/+page.svelte
@@ -10,7 +10,7 @@
 	import EmptyState from '$lib/components/EmptyState.svelte'
 	import { Separator } from '$lib/components/ui/separator'
 	import { Button } from '$lib/components/ui/button'
-	import { Globe, Loader, ChevronDown, SquarePen, Trash2, EllipsisVertical, ArrowLeftRight, Download, CirclePlus } from 'lucide-svelte'
+	import { Globe, Loader, ChevronDown, SquarePen, Trash2, EllipsisVertical, ArrowLeftRight, Download, CirclePlus, Terminal, Check, Copy } from 'lucide-svelte'
 	import { useSidebar } from '$lib/components/ui/sidebar'
 	import { page } from '$app/state'
 	import type { Site } from '$lib/common/models/Site'
@@ -165,6 +165,28 @@
 	}
 
 	let is_create_site_instructions_open = $state(false)
+
+	let is_develop_locally_open = $state(false)
+	const server_url = $derived(self.baseURL || (typeof location !== 'undefined' ? location.origin : ''))
+	const develop_steps = $derived([
+		{ label: 'Install the CLI', command: 'npm install -g primo-cli' },
+		{ label: 'Pull your workspace into the current folder', command: `primo pull -s ${server_url}`, note: "You'll be prompted to log in the first time." },
+		{ label: 'Edit the files with a local agent or by hand', note: 'Open the folder in your editor or point an AI agent at it — sites are plain files.' },
+		{ label: 'Push your changes back to the server', command: 'primo push' }
+	])
+
+	let copied_command: string | null = $state(null)
+	let copied_timeout: ReturnType<typeof setTimeout> | null = null
+	async function copy_command(command: string) {
+		try {
+			await navigator.clipboard.writeText(command)
+			copied_command = command
+			if (copied_timeout) clearTimeout(copied_timeout)
+			copied_timeout = setTimeout(() => (copied_command = null), 1500)
+		} catch (error) {
+			console.error('Failed to copy command:', error)
+		}
+	}
 </script>
 
 <header class="flex h-14 shrink-0 items-center gap-2">
@@ -195,7 +217,11 @@
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</div>
-	<div class="ml-auto mr-4">
+	<div class="ml-auto mr-4 flex items-center gap-2">
+		<Button size="sm" variant="ghost" onclick={() => (is_develop_locally_open = true)}>
+			<Terminal class="h-4 w-4" />
+			Develop locally
+		</Button>
 		<Button
 			size="sm"
 			variant="outline"
@@ -420,6 +446,55 @@
 
 		<Dialog.Footer class="mt-6">
 			<Button type="button" onclick={() => (is_create_site_instructions_open = false)}>Okay</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root bind:open={is_develop_locally_open}>
+	<Dialog.Content class="sm:max-w-[525px] pt-12 gap-0">
+		<h2 class="text-lg font-semibold leading-none tracking-tight">Develop locally</h2>
+		<p class="text-muted-foreground text-sm mb-6">Pull this server's sites to your machine to edit them as files. Run these in your terminal:</p>
+
+		<div class="space-y-4">
+			{#each develop_steps as step, i}
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">{i + 1}</div>
+					<div class="min-w-0 flex-1">
+						<h3 class="font-medium text-sm mb-1">{step.label}</h3>
+						{#if step.command}
+							<button
+								type="button"
+								onclick={() => copy_command(step.command)}
+								class="group flex w-full items-center justify-between gap-2 rounded-md bg-[#111] px-3 py-2 text-left font-mono text-xs text-muted-foreground hover:text-foreground"
+							>
+								<span class="truncate">{step.command}</span>
+								{#if copied_command === step.command}
+									<Check class="h-3.5 w-3.5 flex-shrink-0 text-green-500" />
+								{:else}
+									<Copy class="h-3.5 w-3.5 flex-shrink-0 opacity-50 group-hover:opacity-100" />
+								{/if}
+							</button>
+						{/if}
+						{#if step.note}
+							<p class="text-muted-foreground text-xs mt-1">{step.note}</p>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<p class="text-muted-foreground text-xs mt-6">Pulling copies every site on this server into the current folder.</p>
+
+		<Dialog.Footer class="mt-6 sm:justify-between sm:items-center">
+			<a
+				href="https://docs.primo.build/getting-started/installation"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4"
+			>
+				View docs
+			</a>
+			<Button type="button" onclick={() => (is_develop_locally_open = false)}>Okay</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
Adds a **Develop locally** button + dialog to the dashboard (`/admin/dashboard/sites`), giving editors an in-product path from the visual CMS to the file-based workflow.

## What

- Ghost-style **Develop locally** button in the header, next to **Create Site**.
- Dialog with the pull → edit → push loop:
  1. Install the CLI — `npm install -g primo-cli`
  2. Pull the workspace — `primo pull -s <server-url>` (pre-filled with this server's origin; prompts for login on first run)
  3. Edit with a local agent or by hand — sites are plain files
  4. Push changes back — `primo push`
- Each command has a click-to-copy row (Copy → Check, resets after ~1.5s).
- **View docs** link in the footer → docs.primo.build installation guide.

## Notes

- Dashboard-only for now. A site-scoped "pull this site" action would need a `--site` flag on the CLI (the server's `/api/primo/export/{siteId}` already supports it) — deferred.
- The pre-filled URL uses `self.baseURL`. In production frontend + server share one origin so it's correct; in the split-port dev setup it may show the Vite origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Develop locally” option to the sites dashboard.
  * Introduced a step-by-step dialog with local development instructions.
  * Added one-click command copying with visual confirmation.
  * Included links to relevant documentation and an option to close the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->