### PR TITLE
Fix broken Railway deploy links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Primo is a CMS for developers who build sites for clients who need to manage the
 
 **One-click deploy:**
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/primo?referralCode=RCPU7k)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/palacms?referralCode=RCPU7k)
 
 ![screenshot](https://cdn.primo.page/f52960e1-0bb0-4c64-9f70-5a9994ce95fc/staging/_images/1739675414227Screenshot%202025-02-15%20at%2010.10.10%E2%80%AFPM.png)
 
@@ -38,7 +38,7 @@ Your clients keep editing content in the browser the whole time. Code and conten
 
 The easiest way to get started is Railway:
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/primo?referralCode=RCPU7k)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/palacms?referralCode=RCPU7k)
 
 Or run it anywhere Docker runs:
 


### PR DESCRIPTION
Both "Deploy on Railway" buttons in the README pointed to `railway.com/deploy/primo?referralCode=RCPU7k`, which returns **404** — that slug was never created.

Repointed both to `railway.com/deploy/palacms?referralCode=RCPU7k`, which returns **200** and is the live template (title "Deploy Primo", "Agent-native visual CMS").

The eventual `palacms → primocms` template rename is already tracked in `go-to-market/TODO.md`; once that's done these links should be updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Railway deployment buttons to use the `palacms` deployment target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->